### PR TITLE
Fix constant collision

### DIFF
--- a/decidim-system/app/controllers/decidim/system/devise/passwords_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/devise/passwords_controller.rb
@@ -3,7 +3,7 @@ module Decidim
   module System
     module Devise
       # A controller so admins can recover their passwords.
-      class PasswordsController < Devise::PasswordsController
+      class PasswordsController < ::Devise::PasswordsController
         layout "decidim/system/login"
       end
     end


### PR DESCRIPTION
We have to manually specify the top level constant as eager loading in production vs lazy loading on development are inconsistent. YAY.