### PR TITLE
Add DroneCI support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,5 @@
 build:
-  image: codegram/rails:2.3.0
+  image: codegram/rails:2.3.1
   environment:
     - RAILS_ENV=test
     - DATABASE_HOST=localhost

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,5 @@
 build:
-  image: ruby:2.3.1
+  image: codegram/rails:2.3.0
   environment:
     - RAILS_ENV=test
     - DATABASE_HOST=localhost

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,25 @@
+build:
+  image: ruby:2.3.1
+  environment:
+    - RAILS_ENV=test
+    - DATABASE_HOST=localhost
+    - DATABASE_USERNAME=postgres
+    - DATABASE_PASSWORD=mysecretpassword
+    - GEM_HOME=vendor/bundle
+  commands:
+    - bundle install
+    - bundle exec rake
+
+compose:
+  database:
+    image: postgres
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=mysecretpassword
+  redis:
+    image: redis
+
+cache:
+  mount:
+    - vendor/bundle
+    - public/assets

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,9 +16,6 @@ compose:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=mysecretpassword
-  redis:
-    image: redis
-
 cache:
   mount:
     - vendor/bundle

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/spec/*_dummy_app
 .byebug_history
 pkg/
+vendor/bundle

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Code Climate](https://codeclimate.com/github/codegram/decidim/badges/gpa.svg)](https://codeclimate.com/github/codegram/decidim)
 [![Issue Count](https://codeclimate.com/github/codegram/decidim/badges/issue_count.svg)](https://codeclimate.com/github/codegram/decidim)
 [![Circle CI](https://circleci.com/gh/codegram/decidim.svg?style=svg)](https://circleci.com/gh/codegram/decidim/tree/master)
+[![Build Status](http://ci.decidim.codegram.com/api/badges/codegram/decidim/status.svg)](http://ci.decidim.codegram.com/codegram/decidim)
 [![codecov](https://codecov.io/gh/codegram/decidim/branch/master/graph/badge.svg)](https://codecov.io/gh/codegram/decidim)
 
 ## Installation instructions


### PR DESCRIPTION
#### :tophat: What? Why?

I deployed a drone ci stack in our rancher server in case we want to run the builds through docker. It's not mandatory for now because circle ci is working well but if we want to deploy the application using docker it's best to use the same test environment.

The drone ci server can be accessed through this link: http://ci.decidim.codegram.com

#### :ghost: GIF
![](https://media.giphy.com/media/UhZ4aTuiZeKha/giphy.gif)