### PR TITLE
Mount public folder as a docker volume

### DIFF
--- a/lib/generators/decidim/templates/Dockerfile.erb
+++ b/lib/generators/decidim/templates/Dockerfile.erb
@@ -8,6 +8,8 @@ ENV APP_HOME /code
 ENV RAILS_ENV $rails_env
 ENV SECRET_KEY_BASE $secret_key_base
 
+VOLUME ["/$APP_HOME/public"]
+
 RUN apt-get update
 
 RUN curl -sL https://deb.nodesource.com/setup_5.x | bash && \


### PR DESCRIPTION
#### :tophat: What? Why?

I want to share public folder as a docker volume in order to mount the folder in another container so I can serve static assets using a real web server.

#### :ghost: GIF
![](https://media.giphy.com/media/OLyqxT26UvPCU/giphy.gif)
