### PR TITLE
The volume must be declared when running the container

### DIFF
--- a/lib/generators/decidim/templates/Dockerfile.erb
+++ b/lib/generators/decidim/templates/Dockerfile.erb
@@ -8,8 +8,6 @@ ENV APP_HOME /code
 ENV RAILS_ENV $rails_env
 ENV SECRET_KEY_BASE $secret_key_base
 
-VOLUME ["/$APP_HOME/public"]
-
 RUN apt-get update
 
 RUN curl -sL https://deb.nodesource.com/setup_5.x | bash && \


### PR DESCRIPTION
#### :tophat: What? Why?

I was wrong in #32 . The docker volume must be declared when running the container. Otherwise the assets folder is deleted.

#### :ghost: GIF
![](https://media.giphy.com/media/Wu1Yd3cZO4Ims/giphy.gif)
