### PR TITLE
Add Heroku deploy button

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -31,3 +31,4 @@ exclude_paths:
 - spec/
 - decidim-core/spec/
 - .rubocop.yml
+- lib/generators/decidim/templates/app.json.erb

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -65,7 +65,7 @@ module Decidim
       end
 
       def secret_token
-        require 'securerandom'
+        require "securerandom"
         SecureRandom.hex(64)
       end
 

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -52,8 +52,20 @@ module Decidim
         template "docker-compose.yml.erb", "docker-compose.yml"
       end
 
+      def database_yml
+        template "database.yml.erb", "config/database.yml", force: true
+      end
+
       def cable_yml
         template "cable.yml.erb", "config/cable.yml", force: true
+      end
+
+      def readme
+        template "README.md.erb", "README.md", force: true
+      end
+
+      def app_json
+        template "app.json.erb", "app.json"
       end
 
       private

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -64,6 +64,11 @@ module Decidim
         template "README.md.erb", "README.md", force: true
       end
 
+      def secret_token
+        require 'securerandom'
+        SecureRandom.hex(64)
+      end
+
       def app_json
         template "app.json.erb", "app.json"
       end

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -75,6 +75,52 @@ module Decidim
         end
       end
 
+      def smtp_environment
+        inject_into_file "config/environments/production.rb",
+                         after: "config.log_formatter = ::Logger::Formatter.new" do
+        %{
+
+  config.action_mailer.smtp_settings = {
+    :address        => Rails.application.secrets.smtp_address,
+    :port           => Rails.application.secrets.smtp_port,
+    :authentication => Rails.application.secrets.smtp_authentication,
+    :user_name      => Rails.application.secrets.smtp_username,
+    :password       => Rails.application.secrets.smtp_password,
+    :domain         => Rails.application.secrets.smtp_domain,
+    :enable_starttls_auto => Rails.application.secrets.smtp_starttls_auto,
+    :openssl_verify_mode => 'none'
+  }
+
+  if Rails.application.secrets.sendgrid
+    config.action_mailer.default_options = {
+      "X-SMTPAPI" => {
+        filters:  {
+          clicktrack: { settings: { enable: 0 } },
+          opentrack:  { settings: { enable: 0 } }
+        }
+      }.to_json
+    }
+  end
+        }
+        end
+      end
+
+      def smtp_secrets
+        inject_into_file "config/secrets.yml",
+                         after: "secret_key_base: <%= ENV[\"SECRET_KEY_BASE\"] %>" do
+        %{
+  sendgrid: <%= !ENV["SENDGRID_USERNAME"].blank? %>
+  smtp_username: <%= ENV["SMTP_USERNAME"] || ENV["SENDGRID_USERNAME"] %>
+  smtp_password: <%= ENV["SMTP_PASSWORD"] || ENV["SENDGRID_PASSWORD"] %>
+  smtp_address: <%= ENV["SMTP_ADDRESS"] || "smtp.sendgrid.net" %>
+  smtp_domain: <%= ENV["SMTP_DOMAIN"] || "heroku.com" %>
+  smtp_port: "587"
+  smtp_starttls_auto: true
+  smtp_authentication: "plain"
+        }
+        end
+      end
+
       private
 
       def prepare_database

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -24,14 +24,6 @@ module Decidim
         route "mount Decidim::Core::Engine => '/'"
       end
 
-      def app_name
-        options[:app_name] || "decidim_test_app"
-      end
-
-      def database_yml
-        template "database.yml.erb", "config/database.yml", force: true
-      end
-
       def copy_migrations
         rake "railties:install:migrations"
         prepare_database if options[:migrate]

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -78,7 +78,7 @@ module Decidim
       def smtp_environment
         inject_into_file "config/environments/production.rb",
                          after: "config.log_formatter = ::Logger::Formatter.new" do
-          %{
+          %(
 
   config.action_mailer.smtp_settings = {
     :address        => Rails.application.secrets.smtp_address,
@@ -101,14 +101,14 @@ module Decidim
       }.to_json
     }
   end
-          }
+          )
         end
       end
 
       def smtp_secrets
         inject_into_file "config/secrets.yml",
                          after: "secret_key_base: <%= ENV[\"SECRET_KEY_BASE\"] %>" do
-          %{
+          %(
   sendgrid: <%= !ENV["SENDGRID_USERNAME"].blank? %>
   smtp_username: <%= ENV["SMTP_USERNAME"] || ENV["SENDGRID_USERNAME"] %>
   smtp_password: <%= ENV["SMTP_PASSWORD"] || ENV["SENDGRID_PASSWORD"] %>
@@ -117,7 +117,7 @@ module Decidim
   smtp_port: "587"
   smtp_starttls_auto: true
   smtp_authentication: "plain"
-          }
+          )
         end
       end
 

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -78,7 +78,7 @@ module Decidim
       def smtp_environment
         inject_into_file "config/environments/production.rb",
                          after: "config.log_formatter = ::Logger::Formatter.new" do
-        %{
+          %{
 
   config.action_mailer.smtp_settings = {
     :address        => Rails.application.secrets.smtp_address,
@@ -101,14 +101,14 @@ module Decidim
       }.to_json
     }
   end
-        }
+          }
         end
       end
 
       def smtp_secrets
         inject_into_file "config/secrets.yml",
                          after: "secret_key_base: <%= ENV[\"SECRET_KEY_BASE\"] %>" do
-        %{
+          %{
   sendgrid: <%= !ENV["SENDGRID_USERNAME"].blank? %>
   smtp_username: <%= ENV["SMTP_USERNAME"] || ENV["SENDGRID_USERNAME"] %>
   smtp_password: <%= ENV["SMTP_PASSWORD"] || ENV["SENDGRID_PASSWORD"] %>
@@ -117,7 +117,7 @@ module Decidim
   smtp_port: "587"
   smtp_starttls_auto: true
   smtp_authentication: "plain"
-        }
+          }
         end
       end
 

--- a/lib/generators/decidim/templates/README.md.erb
+++ b/lib/generators/decidim/templates/README.md.erb
@@ -1,0 +1,26 @@
+# README
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+This README would normally document whatever steps are necessary to get the
+application up and running.
+
+Things you may want to cover:
+
+* Ruby version
+
+* System dependencies
+
+* Configuration
+
+* Database creation
+
+* Database initialization
+
+* How to run the test suite
+
+* Services (job queues, cache servers, search engines, etc.)
+
+* Deployment instructions
+
+* ...

--- a/lib/generators/decidim/templates/app.json.erb
+++ b/lib/generators/decidim/templates/app.json.erb
@@ -11,5 +11,7 @@
     "memcachier:developer",
     "rollbar:free"
   ],
-  "env": {}
+  "env": {
+    "SECRET_KEY_BASE": "changemeplease"
+  }
 }

--- a/lib/generators/decidim/templates/app.json.erb
+++ b/lib/generators/decidim/templates/app.json.erb
@@ -5,13 +5,9 @@
   "addons": [
     "heroku-postgresql:hobby-dev",
     "heroku-redis:hobby-dev",
-    "newrelic:wayne",
-    "papertrail:choklad",
-    "sendgrid:starter",
-    "memcachier:developer",
-    "rollbar:free"
+    "sendgrid:starter"
   ],
   "env": {
-    "SECRET_KEY_BASE": "changemeplease"
+    "SECRET_KEY_BASE": "<%= secret_token %>"
   }
 }

--- a/lib/generators/decidim/templates/app.json.erb
+++ b/lib/generators/decidim/templates/app.json.erb
@@ -1,0 +1,11 @@
+{
+  "name": "<%= app_name %>",
+  "description": "TODO: Add a short description about <%= app_name %>",
+  "keywords": [
+    "small",
+    "sharp",
+    "tool"
+  ],
+  "addons": [],
+  "env": {}
+}

--- a/lib/generators/decidim/templates/app.json.erb
+++ b/lib/generators/decidim/templates/app.json.erb
@@ -1,11 +1,15 @@
 {
   "name": "<%= app_name %>",
   "description": "TODO: Add a short description about <%= app_name %>",
-  "keywords": [
-    "small",
-    "sharp",
-    "tool"
+  "keywords": [],
+  "addons": [
+    "heroku-postgresql:hobby-dev",
+    "heroku-redis:hobby-dev",
+    "newrelic:wayne",
+    "papertrail:choklad",
+    "sendgrid:starter",
+    "memcachier:developer",
+    "rollbar:free"
   ],
-  "addons": [],
   "env": {}
 }


### PR DESCRIPTION
#### :tophat: What? Why?

This PR finishes #14. I added `app.json` and `README.md` to app generator in order to create those files when generating a new app.

As an extra bonus I fixed the Docker base image for `decidim` including `decidim-dev` engine.

#### :dart: Acceptance criteria?

`app.json` exists and `README.md` includes Heroku deploy button.

#### :pushpin: Related tasks?

- Issue #14

#### :ghost: GIF
![](https://media.giphy.com/media/JTmt4C8AjGzxm/giphy.gif)