### PR TITLE
Add per engine seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,27 @@ $ cd decidim_application
 
 **Note**: *These steps will be replaced by a simple `gem install decidim && decidim decidim_application` once the gem is released.*
 
-You should now create your database and migrate:
+You should now setup your database:
 
 ```
-$ rails db:create
-$ rails db:migrate
+$ rails db:setup
+```
+
+This will also create some default data so you can start testing the app:
+
+* A `Decidim::System::Admin` with email `system@decidim.org` and password
+ `decidim123456`, to log in at `/system`.
+* A `Decidim::Organization` named `Decidim Staging`. You probably want to
+  change its name and hostname to match your needs.
+* A `Decidim::User` acting as an admin for the organization, with email
+ `admin@decidim.org` and password `decidim123456`
+* A `Decidim::User` that also belongs to the organization but it's a regular
+  user.
+
+This data won't be created in production environments, if you still want to do it, run:
+
+```
+$ SEED=true rails db:setup
 ```
 
 You can now start your server!

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -1,0 +1,23 @@
+if !Rails.env.production? || ENV["SEED"]
+  puts "Creating Decidim::Core seeds..."
+
+  staging_organization = Decidim::Organization.create!(
+    name: "Decidim Staging",
+    host: "staging.decidim.codegram.com"
+  )
+
+  Decidim::User.create!(
+    email: "admin@decidim.org",
+    password: "decidim123456",
+    password_confirmation: "decidim123456",
+    organization: staging_organization,
+    roles: ["admin"]
+  )
+
+  Decidim::User.create!(
+    email: "user@decidim.org",
+    password: "decidim123456",
+    password_confirmation: "decidim123456",
+    organization: staging_organization
+  )
+end

--- a/decidim-system/db/seeds.rb
+++ b/decidim-system/db/seeds.rb
@@ -1,0 +1,9 @@
+if !Rails.env.production? || ENV["SEED"]
+  puts "Creating Decidim::System seeds..."
+
+  Decidim::System::Admin.create!(
+    email: "system@decidim.org",
+    password: "decidim123456",
+    password_confirmation: "decidim123456"
+  )
+end

--- a/lib/decidim.rb
+++ b/lib/decidim.rb
@@ -5,4 +5,10 @@ require "decidim/admin"
 
 # Module declaration.
 module Decidim
+  # Loads seeds from all engines.
+  def self.seed!
+    Rails.application.railties.select do |railtie|
+      railtie.respond_to?(:load_seed) && railtie.class.name.include?("Decidim::")
+    end.each(&:load_seed)
+  end
 end

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -38,7 +38,7 @@ module Decidim
       end
 
       def add_seeds
-        append_file "db/seeds.rb", "Decidim::Core::Engine.load_seed"
+        append_file "db/seeds.rb", "\nDecidim.seed!"
       end
 
       def copy_initializer

--- a/spec/decidim_spec.rb
+++ b/spec/decidim_spec.rb
@@ -5,4 +5,26 @@ describe Decidim do
   it "has a version number" do
     expect(Decidim.version).not_to be nil
   end
+
+  describe "#seed!" do
+    it "loads seeds of every engine" do
+      decidim_railties = [
+        double(load_seed: nil, class: double(name: "Decidim::EngineA")),
+        double(load_seed: nil, class: double(name: "Decidim::EngineB"))
+      ]
+
+      other_railties = [
+        double(load_seed: nil, class: double(name: "Something::EngineA")),
+        double(load_seed: nil, class: double(name: "Something::EngineB"))
+      ]
+
+      decidim_railties.each { |r| expect(r).to receive(:load_seed) }
+      other_railties.each { |r| expect(r).to_not receive(:load_seed) }
+
+      application = double(railties: (decidim_railties + other_railties))
+      expect(Rails).to receive(:application).and_return application
+
+      Decidim.seed!
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Implements #36.

#### :dart: Acceptance criteria?

Generating a new app adds a seeds file and running `rake db:seed` create a System Admin, an Organization, an admin for the organization and a user for the organization.

#### :ghost: GIF
![](http://i.imgur.com/8yanpUy.gif)
