### PR TITLE
Devise: Use symbol as scope. Fixes #59

### DIFF
--- a/decidim-admin/app/constraints/decidim/admin/organization_dashboard_constraint.rb
+++ b/decidim-admin/app/constraints/decidim/admin/organization_dashboard_constraint.rb
@@ -27,7 +27,7 @@ module Decidim
       end
 
       def user
-        return unless request.env["warden"].authenticate!(scope: "user")
+        return unless request.env["warden"].authenticate!(scope: :user)
 
         @user ||= request.env["warden"].user("user")
       end

--- a/decidim-admin/spec/features/admin_access_control.rb
+++ b/decidim-admin/spec/features/admin_access_control.rb
@@ -5,36 +5,48 @@ describe "Admin dashboard access control", type: :feature do
   let(:organization) { create(:organization) }
 
   before do
-    login_as user, scope: :user
     switch_to_host(organization.host)
   end
 
-  context "a regular user" do
-    let(:user) { create(:user, organization: organization) }
+  context "when authenticated" do
+    before do
+      login_as user, scope: :user
+    end
 
-    it "can't access the admin dashboard" do
-      visit decidim_admin.root_path
-      expect(page.status_code).to eq(404)
+    context "a regular user" do
+      let(:user) { create(:user, organization: organization) }
+
+      it "can't access the admin dashboard" do
+        visit decidim_admin.root_path
+        expect(page.status_code).to eq(404)
+      end
+    end
+
+    context "an organization admin" do
+      let(:user) { create(:user, :admin, organization: organization) }
+
+      it "can access the admin dashboard" do
+        visit decidim_admin.root_path
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content("Dashboard")
+      end
+    end
+
+    context "an admin from another organization" do
+      let(:other_organization) { create(:organization) }
+      let(:user) { create(:user, :admin, organization: other_organization) }
+
+      it "can't access the admin dashboard" do
+        visit decidim_admin.root_path
+        expect(page.status_code).to eq(404)
+      end
     end
   end
 
-  context "an organization admin" do
-    let(:user) { create(:user, :admin, organization: organization) }
-
-    it "can access the admin dashboard" do
-      visit decidim_admin.root_path
-      expect(page.status_code).to eq(200)
-      expect(page).to have_content("Dashboard")
-    end
-  end
-
-  context "an admin from another organization" do
-    let(:other_organization) { create(:organization) }
-    let(:user) { create(:user, :admin, organization: other_organization) }
-
+  describe "when unauthenticated" do
     it "can't access the admin dashboard" do
       visit decidim_admin.root_path
-      expect(page.status_code).to eq(404)
+      expect(page.body).to include("You need to sign in")
     end
   end
 end


### PR DESCRIPTION
This fixes the bug described in #59