### PR TITLE
Fix install task so Drone CI doesn't complain

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ build:
   commands:
     - bundle install
     - bundle exec rake
-
+    - bundle exec rspec
 compose:
   database:
     image: postgres

--- a/decidim-dev/lib/generators/decidim/dummy_generator.rb
+++ b/decidim-dev/lib/generators/decidim/dummy_generator.rb
@@ -21,9 +21,6 @@ module Decidim
       class_option :engine_path, type: :string,
                                  desc: "The library where the dummy app will be installed"
 
-      class_option :migrate, type: :boolean, default: false,
-                             desc: "Run migrations after installing decidim"
-
       def cleanup
         remove_directory_if_exists(dummy_path)
       end
@@ -36,7 +33,7 @@ module Decidim
           "--skip-git",
           "--skip-keeps",
           "--skip-test",
-          "--migrate=#{options[:migrate]}"
+          "--recreate_db"
         ]
       end
 

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -37,23 +37,19 @@ module Decidim
       class_option :database, type: :string, aliases: "-d", default: "postgresql",
                               desc: "Configure for selected database (options: #{DATABASES.join("/")})"
 
+      class_option :recreate_db, type: :boolean, default: false,
+                                 desc: "Recreate test database"
+
       class_option :migrate, type: :boolean, default: false,
                              desc: "Run migrations after installing decidim"
 
-      def install
-        Decidim::Generators::InstallGenerator.start [
-          "--migrate=#{options[:migrate]}",
-          "--app_name=#{app_name}"
-        ]
+      def database_yml
+        template "database.yml.erb", "config/database.yml", force: true
       end
 
       def docker
         template "Dockerfile.erb", "Dockerfile"
         template "docker-compose.yml.erb", "docker-compose.yml"
-      end
-
-      def database_yml
-        template "database.yml.erb", "config/database.yml", force: true
       end
 
       def cable_yml
@@ -71,6 +67,14 @@ module Decidim
 
       def app_json
         template "app.json.erb", "app.json"
+      end
+
+      def install
+        Decidim::Generators::InstallGenerator.start [
+          "--recreate_db=#{options[:recreate_db]}",
+          "--migrate=#{options[:migrate]}",
+          "--app_name=#{app_name}"
+        ]
       end
 
       private

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -124,9 +124,9 @@ module Decidim
       private
 
       def prepare_database
-        rake "db:drop RAILS_ENV=development"
-        rake "db:create RAILS_ENV=development"
-        rake "db:migrate RAILS_ENV=development"
+        rake "db:drop RAILS_ENV=test"
+        rake "db:create RAILS_ENV=test"
+        rake "db:migrate RAILS_ENV=test"
         rake "db:test:prepare"
       end
     end

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -17,6 +17,8 @@ module Decidim
                               desc: "The name of the app"
       class_option :migrate, type: :boolean, default: false,
                              desc: "Run migrations after installing decidim"
+      class_option :recreate_db, type: :boolean, default: false,
+                                 desc: "Run migrations after installing decidim"
 
       def install
         route "mount Decidim::System::Engine => '/system'"
@@ -26,7 +28,8 @@ module Decidim
 
       def copy_migrations
         rake "railties:install:migrations"
-        prepare_database if options[:migrate]
+        recreate_db if options[:recreate_db]
+        rake "db:migrate" if options[:migrate]
       end
 
       def add_seeds
@@ -123,11 +126,10 @@ module Decidim
 
       private
 
-      def prepare_database
+      def recreate_db
         rake "db:drop RAILS_ENV=test"
         rake "db:create RAILS_ENV=test"
         rake "db:migrate RAILS_ENV=test"
-        rake "db:test:prepare"
       end
     end
   end


### PR DESCRIPTION
We're overriding the default environment when performing the `prepare_database` tasks. Not sure why, let's find out if this works.