### PR TITLE
Remove line count linters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1098,10 +1098,12 @@ Metrics/BlockNesting:
 Metrics/ClassLength:
   CountComments: false  # count full line comments?
   Max: 100
+  Enabled: false
 
 Metrics/ModuleLength:
   CountComments: false  # count full line comments?
   Max: 100
+  Enabled: false
 
 # Avoid complex methods.
 Metrics/CyclomaticComplexity:
@@ -1120,6 +1122,7 @@ Metrics/LineLength:
 Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 15
+  Enabled: false
 
 Metrics/ParameterLists:
   Max: 5


### PR DESCRIPTION
#### :tophat: What? Why?

I don't agree limiting the number of lines in a method or file as a fixed number. I think if something is doing too many thinks we'll realize during the review in a pull request, no need to add hard limits on this.

Currently this triggers errors on these (which make no sense splitting):

https://github.com/codegram/decidim/blob/master/lib/generators/decidim/install_generator.rb#L12

https://github.com/codegram/decidim/blob/master/lib/generators/decidim/install_generator.rb#L78

#### :ghost: GIF
![](http://i.imgur.com/GC8IJCk.gif)
