### PR TITLE
Devise isn't using the overriden views

### DIFF
--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -2,8 +2,8 @@
 require "rails"
 require "active_support/all"
 
-require "decidim/core"
 require "devise"
+require "decidim/core"
 require "jquery-rails"
 require "sass-rails"
 require "turbolinks"

--- a/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+module Decidim
+  module Devise
+    class PasswordsController < ::Devise::PasswordsController
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+module Decidim
+  module Devise
+    class SessionsController < ::Devise::SessionsController
+    end
+  end
+end

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -6,7 +6,9 @@ Decidim::Core::Engine.routes.draw do
              module: :devise,
              router_name: :decidim,
              controllers: {
-               invitations: "decidim/devise/invitations"
+               invitations: "decidim/devise/invitations",
+               sessions: "decidim/devise/sessions",
+               passwords: "decidim/devise/passwords"
              }
   root to: "home#show"
 end

--- a/decidim-system/app/controllers/decidim/system/devise/passwords_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/devise/passwords_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Decidim
+  module System
+    module Devise
+      class PasswordsController < ::Devise::PasswordsController
+      end
+    end
+  end
+end

--- a/decidim-system/app/controllers/decidim/system/devise/sessions_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/devise/sessions_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Decidim
+  module System
+    module Devise
+      class SessionsController < ::Devise::SessionsController
+      end
+    end
+  end
+end

--- a/decidim-system/config/routes.rb
+++ b/decidim-system/config/routes.rb
@@ -3,7 +3,11 @@ Decidim::System::Engine.routes.draw do
   devise_for :admins,
              class_name: "Decidim::System::Admin",
              module: :devise,
-             router_name: "decidim_system"
+             router_name: :decidim_system,
+             controllers: {
+               sessions: "decidim/system/devise/sessions",
+               passwords: "decidim/system/devise/passwords"
+             }
 
   authenticate(:admin) do
     resources :organizations

--- a/decidim-system/lib/decidim/system/engine.rb
+++ b/decidim-system/lib/decidim/system/engine.rb
@@ -2,8 +2,8 @@
 require "rails"
 require "active_support/all"
 
-require "decidim/core"
 require "devise"
+require "decidim/core"
 require "jquery-rails"
 require "sass-rails"
 require "turbolinks"


### PR DESCRIPTION
<img width="615" alt="screen shot 2016-10-04 at 1 14 31 pm" src="https://cloud.githubusercontent.com/assets/111746/19072252/85699552-8a34-11e6-85ac-6cc318142934.png">

As you can see, the labels are duplicated. This happens because of using our own views, devise is using its own - as the form helpers are actually using `foundation_rails_helpers`, which already include labels automatically, ends up like this.