### PR TITLE
Don't cache assets in Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,4 +19,3 @@ compose:
 cache:
   mount:
     - vendor/bundle
-    - public/assets


### PR DESCRIPTION
#### :tophat: What? Why?

Drone was trying to cache assets that didn't exist.

#### :dart: Acceptance criteria?

The error message related to `public/assets` not found should disappear.

#### :ghost: GIF
![](https://media.giphy.com/media/Fd3lB3oEBYCac/giphy.gif)
