### PR TITLE
Add multi-language input helper

### DIFF
--- a/decidim-core/app/helpers/decidim/translations_helper.rb
+++ b/decidim-core/app/helpers/decidim/translations_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Decidim
+  # Helper that provides convenient methods to deal with translated attributes.
+  module TranslationsHelper
+    # Public: Returns the translation of an attribute using the current locale,
+    # if available.
+    #
+    # attribute - A Hash where keys (strings) are locales, and their values are
+    #             the translation for each locale.
+    #
+    # Returns a String with the translation.
+    def translated_attribute(attribute)
+      attribute.try(:[], I18n.locale.to_s)
+    end
+  end
+end

--- a/decidim-core/db/migrate/20161005153007_add_description_to_organizations.rb
+++ b/decidim-core/db/migrate/20161005153007_add_description_to_organizations.rb
@@ -1,0 +1,9 @@
+class AddDescriptionToOrganizations < ActiveRecord::Migration[5.0]
+  def change
+    enable_extension :hstore
+
+    change_table :decidim_organizations do |t|
+      t.hstore :description
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -2,6 +2,9 @@
 require "decidim/core/engine"
 require "decidim/core/version"
 
+require "decidim/translatable_attributes"
+require "decidim/form_builder"
+
 # Decidim configuration.
 module Decidim
   @config = OpenStruct.new

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -30,6 +30,10 @@ module Decidim
       initializer "decidim.middleware" do |app|
         app.config.middleware.use Decidim::CurrentOrganization
       end
+
+      initializer "decidim.default_form_builder" do |_app|
+        ActionView::Base.default_form_builder = Decidim::FormBuilder
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require "foundation_rails_helper/form_builder"
+
+module Decidim
+  # This custom FormBuilder adds fields needed to deal with translatable fields,
+  # following the conventions set on `Decidim::TranslatableAttributes`.
+  class FormBuilder < FoundationRailsHelper::FormBuilder
+    # Public: Generates an form field for each locale.
+    #
+    # type - The form field's type, like `text_area` or `text_input`
+    # name - The name of the field
+    # options - The set of options to send to the field
+    #
+    # Renders form fields for each locale.
+    def translated(type, name, options = {})
+      locales.map do |locale|
+        label = options[:label] || label_for(name)
+        language = locale
+
+        send(type, "#{name}_#{locale}", options.merge(label: "#{label} (#{language})"))
+      end.join.html_safe
+    end
+
+    private
+
+    def locales
+      I18n.available_locales
+    end
+
+    def label_for(attribute)
+      if object.class.respond_to?(:human_attribute_name)
+        object.class.human_attribute_name(attribute)
+      else
+        attribute.to_s.humanize
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/translatable_attributes.rb
+++ b/decidim-core/lib/decidim/translatable_attributes.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+require "active_support/concern"
+
+module Decidim
+  # A set of convenience methods to deal with I18n attributes and validations
+  # in a way that's compatible with Virtus and ActiveModel, thus making it easy
+  # to integrate into Rails' forms and similar workflows.
+  module TranslatableAttributes
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Public: Mirrors Virtus' `attribute` interface to define attributes in
+      # multiple locales.
+      #
+      # name - The attribute's name
+      # type - The attribute's Type
+      #
+      # Example:
+      #
+      #   translatable_attribute(:name, String)
+      #   # This will generate: `name_ca`, `name_en`, `name_ca=`, `name_en=`
+      #   # and will keep them synchronized with a hash in `name`:
+      #   # name = { "ca" => "Hola", "en" => "Hello" }
+      #
+      # Returns nothing.
+      def translatable_attribute(name, type, *options)
+        attribute name, Hash, default: {}
+
+        locales.each do |locale|
+          attribute_name = "#{name}_#{locale}"
+
+          attribute attribute_name, type, *options
+
+          define_method attribute_name do
+            translatable_attribute_getter(name, locale)
+          end
+
+          alias_method "#{attribute_name}_virtus=", "#{attribute_name}="
+
+          define_method "#{attribute_name}=" do |value|
+            new_value = send("#{attribute_name}_virtus=", value)
+            translatable_attribute_setter(name, locale, new_value)
+          end
+        end
+      end
+
+      # Public: Mirrors ActiveModel's `validates` interface to define
+      # validations in multiple locales.
+      #
+      # *arguments - The exact same arguments `validates` would receive.
+      #
+      # Example:
+      #
+      #   translatable_validates :name, :description, presence: true
+      #   # This will validate the presence of `name_ca` and `name_en`
+      #
+      # Returns nothing.
+      def translatable_validates(*arguments)
+        options = arguments.last
+        fields = arguments[0..-2]
+
+        localized_fields = fields.flat_map do |f|
+          locales.map { |locale| "#{f}_#{locale}" }
+        end
+
+        validation_arguments = localized_fields + [options]
+        validates(*validation_arguments)
+      end
+
+      def locales
+        I18n.available_locales
+      end
+    end
+
+    private
+
+    def translatable_attribute_setter(name, locale, value)
+      public_send("#{name}=", (public_send(name) || {}).merge(locale => value))
+    end
+
+    def translatable_attribute_getter(name, locale)
+      field = public_send(name) || {}
+      field[locale.to_s] || field[locale.to_sym]
+    end
+  end
+end

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :organization, class: Decidim::Organization do
     sequence(:name) { |n| "Citizen Corp ##{n}" }
     sequence(:host) { |n| "#{n}.citizen.corp" }
+    description     "Description"
   end
 
   factory :process, class: Decidim::ParticipatoryProcess do

--- a/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
@@ -1,0 +1,16 @@
+# coding: utf-8
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe TranslationsHelper do
+    describe "#translated_attribute" do
+      it "translates the attribute against the current locale" do
+        attribute = { "ca" => "Hola", "zh-CN" => "你好" }
+        I18n.locale = :'zh-CN'
+
+        expect(helper.translated_attribute(attribute)).to eq("你好")
+      end
+    end
+  end
+end

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "nokogiri"
+
+module Decidim
+  describe FormBuilder do
+    let(:helper) { Class.new(ActionView::Base).new }
+
+    let(:resource) do
+      Class.new do
+        def self.model_name
+          ActiveModel::Name.new(self, nil, "dummy")
+        end
+
+        include ActiveModel::Model
+        include Virtus.model
+        include TranslatableAttributes
+
+        translatable_attribute :name, String
+      end.new
+    end
+
+    before do
+      allow(I18n).to receive(:available_locales).and_return %w(ca en)
+    end
+
+    let(:builder) { FormBuilder.new(:resource, resource, helper, {}) }
+
+    let(:output) do
+      builder.translated :text_area, :name
+    end
+
+    it "renders an input for each field" do
+      parsed = Nokogiri::HTML(output)
+
+      expect(parsed.css("textarea[name='resource[name_en]']").first).to be
+      expect(parsed.css("textarea[name='resource[name_en]']").first).to be
+
+      expect(parsed.css("label[for='resource_name_en']").first).to be
+      expect(parsed.css("label[for='resource_name_ca']").first).to be
+    end
+  end
+end

--- a/decidim-core/spec/lib/translatable_attributes_spec.rb
+++ b/decidim-core/spec/lib/translatable_attributes_spec.rb
@@ -1,0 +1,78 @@
+# coding: utf-8
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe TranslatableAttributes do
+    let(:klass) do
+      Class.new do
+        def self.model_name
+          ActiveModel::Name.new(self, nil, "dummy")
+        end
+
+        include ActiveModel::Model
+        include Virtus.model
+        include TranslatableAttributes
+      end
+    end
+
+    let(:available_locales) { %w(en ca) }
+
+    before do
+      allow(I18n).to receive(:available_locales).and_return available_locales
+    end
+
+    let(:model) { klass.new }
+
+    describe "#translatable_attribute do" do
+      before do
+        klass.class_eval do
+          translatable_attribute :name, String
+        end
+      end
+
+      it "creates a getter for each locale" do
+        model.name = { "en" => "Hello", "ca" => "Hola" }
+
+        expect(model.name_en).to eq("Hello")
+        expect(model.name_ca).to eq("Hola")
+      end
+
+      it "creates a setter for each locale" do
+        model.name_en = "Hello"
+        model.name_ca = "Hola"
+
+        expect(model.name).to include("en" => "Hello")
+        expect(model.name).to include("ca" => "Hola")
+      end
+
+      it "coerces values" do
+        model.name_en = 1
+        expect(model.name_en).to eq("1")
+      end
+    end
+
+    describe "#translatable_validates" do
+      before do
+        klass.class_eval do
+          translatable_attribute :name, String
+          translatable_attribute :summary, String
+          translatable_attribute :description, String
+
+          translatable_validates :name, :summary, presence: true
+          translatable_validates :description, length: { maximum: 10 }
+        end
+      end
+
+      it "validates the presence in each locale" do
+        model.name_en = "Hola"
+        model.description_ca = "Una descripció mooooolt llarga"
+
+        expect(model.valid?).to eq(false)
+
+        expect(model.errors).to include(:name_ca, :summary_en, :summary_ca, :description_ca)
+        expect(model.errors).to_not include(:name_en, :description_en)
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/test/rspec_support/i18n.rb
+++ b/decidim-dev/lib/decidim/test/rspec_support/i18n.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+RSpec.configure do |config|
+  config.before(:suite) do
+    I18n.config.enforce_available_locales = false
+  end
+
+  config.around(:each) do |example|
+    previous_locale = I18n.locale
+    example.run
+    I18n.locale = previous_locale
+  end
+end

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -36,7 +36,11 @@ module Decidim
       attr_reader :form
 
       def create_organization
-        Decidim::Organization.create!(name: form.name, host: form.host)
+        Decidim::Organization.create!(
+          name: form.name,
+          host: form.host,
+          description: form.description
+        )
       end
 
       def invite_admin(organization)

--- a/decidim-system/app/commands/decidim/system/update_organization.rb
+++ b/decidim-system/app/commands/decidim/system/update_organization.rb
@@ -42,6 +42,8 @@ module Decidim
       def save_organization
         organization.name = form.name
         organization.host = form.host
+        organization.description = form.description
+
         organization.save!
       end
     end

--- a/decidim-system/app/controllers/decidim/system/application_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/application_controller.rb
@@ -4,6 +4,8 @@ module Decidim
     # The main application controller that inherits from Rails.
     class ApplicationController < ActionController::Base
       protect_from_forgery with: :exception, prepend: true
+
+      helper Decidim::TranslationsHelper
     end
   end
 end

--- a/decidim-system/app/forms/decidim/system/register_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/register_organization_form.rb
@@ -1,14 +1,20 @@
 # frozen_string_literal: true
+require "decidim/translatable_attributes"
+
 module Decidim
   module System
     # A form object used to create organizations from the system dashboard.
     #
     class RegisterOrganizationForm < UpdateOrganizationForm
+      include TranslatableAttributes
+
       mimic :organization
 
       attribute :organization_admin_email, String
 
       validates :organization_admin_email, presence: true
+
+      translatable_attribute :description, String
     end
   end
 end

--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
+require "decidim/translatable_attributes"
+
 module Decidim
   module System
     # A form object used to update organizations from the system dashboard.
     #
     class UpdateOrganizationForm < Rectify::Form
+      include TranslatableAttributes
+
       mimic :organization
 
       attribute :name, String
       attribute :host, String
+
+      translatable_attribute :description, String
 
       validate :validate_organization_uniqueness
 

--- a/decidim-system/app/views/decidim/system/organizations/edit.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/edit.html.erb
@@ -7,6 +7,10 @@
     <%= f.text_field :host %>
   </div>
 
+  <div class="field">
+    <%= f.translated :text_area, :description %>
+  </div>
+
   <div class="actions">
     <%= f.submit t("decidim.system.actions.save") %>
   </div>

--- a/decidim-system/app/views/decidim/system/organizations/new.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/new.html.erb
@@ -12,6 +12,10 @@
   </div>
 
   <div class="field">
+    <%= f.translated :text_area, :description %>
+  </div>
+
+  <div class="field">
     <%= f.email_field :organization_admin_email %>
   </div>
 

--- a/decidim-system/app/views/decidim/system/organizations/show.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title do %>
   <h2><%= link_to @organization.name, @organization %></h2>
   <h3 class="subheader"><%= @organization.host %></h3>
+  <p><%= translated_attribute @organization.description %></p>
 <% end %>
 
 <div class="actions">

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -16,6 +16,7 @@ module Decidim
             {
               name: "Gotham City",
               host: "decide.gotham.gov",
+              description_en: "Fictional city appearing in American comic books.",
               organization_admin_email: "f.laguardia@gotham.gov"
             }
           end
@@ -38,6 +39,7 @@ module Decidim
 
             expect(admin.email).to eq("f.laguardia@gotham.gov")
             expect(admin.organization.name).to eq("Gotham City")
+            expect(admin.organization.description).to include("en" => "Fictional city appearing in American comic books.")
             expect(admin.roles).to include("admin")
             expect(admin).to be_created_by_invite
           end

--- a/decidim-system/spec/features/organizations_spec.rb
+++ b/decidim-system/spec/features/organizations_spec.rb
@@ -51,6 +51,7 @@ describe "Organizations", type: :feature do
       it "edits the data" do
         fill_in "Name", with: "Citizens Rule!"
         fill_in "Host", with: "www.foo.org"
+        fill_in "Description (en)", with: "Organization description."
         click_button "Save"
 
         expect(page).to have_css("div.flash.success")


### PR DESCRIPTION
This adds some multi language input helpers to deal with the fact some attributes are translatable.

It also adds a translated `description` field to organizations, just as a way to check this works.