### PR TITLE
Add Issue and PR badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![Issue Count](https://codeclimate.com/github/codegram/decidim/badges/issue_count.svg)](https://codeclimate.com/github/codegram/decidim/issues)
 [![Build Status](https://travis-ci.org/codegram/decidim.svg?branch=master)](https://travis-ci.org/codegram/decidim)
 [![codecov](https://codecov.io/gh/codegram/decidim/branch/master/graph/badge.svg)](https://codecov.io/gh/codegram/decidim)
+[![Issue Stats](http://issuestats.com/github/codegram/decidim/badge/pr?style=flat)](http://issuestats.com/github/codegram/decidim)
+[![Issue Stats](http://issuestats.com/github/codegram/decidim/badge/issue?style=flat)](http://issuestats.com/github/codegram/decidim)
+
 
 ## Requirements
 


### PR DESCRIPTION
#### :tophat: What? Why?

This adds a couple of very nice badges informing the user of the project's community health: Average time of issues to get addressed, and TTL of PRs.

#### OMG SHOW THEM TO ME

[![Issue Stats](http://issuestats.com/github/codegram/decidim/badge/pr?style=flat)](http://issuestats.com/github/codegram/decidim)
[![Issue Stats](http://issuestats.com/github/codegram/decidim/badge/issue?style=flat)](http://issuestats.com/github/codegram/decidim)

#### :ghost: GIF
![](https://media.giphy.com/media/26AHG5KGFxSkUWw1i/giphy.gif)
