### PR TITLE
Fix coverage reports

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -2,9 +2,6 @@
 require "decidim/core/engine"
 require "decidim/core/version"
 
-require "decidim/translatable_attributes"
-require "decidim/form_builder"
-
 # Decidim configuration.
 module Decidim
   @config = OpenStruct.new

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -14,6 +14,9 @@ require "jbuilder"
 require "active_link_to"
 require "rectify"
 
+require "decidim/translatable_attributes"
+require "decidim/form_builder"
+
 module Decidim
   module Core
     # Decidim's core Rails Engine.


### PR DESCRIPTION
#### :tophat: What? Why?

Codecov isn't taking into account coverage for files that are required before they're supposed to. This should fix it.

#### :dart: Acceptance criteria?

Coverage reports show `form_builder.rb` and `translatable_attributes.rb` as totally covered.

#### :ghost: GIF
![](https://media.giphy.com/media/oYD5oNEq7bf5S/giphy.gif)
