### PR TITLE
Autoload DeviseFailureApp

### DIFF
--- a/decidim-core/config/initializers/devise.rb
+++ b/decidim-core/config/initializers/devise.rb
@@ -2,8 +2,6 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 
-require "decidim/devise_failure_app"
-
 Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -6,6 +6,7 @@ require "decidim/core/version"
 module Decidim
   autoload :TranslatableAttributes, "decidim/translatable_attributes"
   autoload :FormBuilder, "decidim/form_builder"
+  autoload :DeviseFailureApp, "decidim/devise_failure_app"
 
   @config = OpenStruct.new
 


### PR DESCRIPTION
In an attempt to bring the missing coverage to DeviseFailureApp, I realized `DeviseFailureApp` should be autoloaded as the rest of the constants.