### PR TITLE
Revert "Remove Drone CI"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,31 @@
+
+build:
+  image: codegram/rails:2.3.1
+  environment:
+    - RAILS_ENV=test
+    - DATABASE_HOST=localhost
+    - DATABASE_USERNAME=postgres
+    - DATABASE_PASSWORD=mysecretpassword
+    - GEM_HOME=vendor/bundle
+  commands:
+    - bundle install --jobs=3 --retry=3
+    - cd $$GEM;
+    - if [ "$$GEM" == "." ]; then docker build --rm=false -t codegram/decidim .; fi
+    - bundle exec rake
+
+compose:
+  database:
+    image: postgres
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=mysecretpassword
+cache:
+  mount:
+    - vendor/bundle
+
+matrix:
+  GEM:
+    - .
+    - decidim-admin
+    - decidim-core
+    - decidim-system

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Code Climate](https://codeclimate.com/github/codegram/decidim/badges/gpa.svg)](https://codeclimate.com/github/codegram/decidim/trends)
 [![Issue Count](https://codeclimate.com/github/codegram/decidim/badges/issue_count.svg)](https://codeclimate.com/github/codegram/decidim/issues)
 [![Build Status](https://travis-ci.org/codegram/decidim.svg?branch=master)](https://travis-ci.org/codegram/decidim)
+[![Build Status](http://ci.decidim.codegram.com/api/badges/codegram/decidim/status.svg)](http://ci.decidim.codegram.com/codegram/decidim)
 [![codecov](https://codecov.io/gh/codegram/decidim/branch/master/graph/badge.svg)](https://codecov.io/gh/codegram/decidim)
 [![Dependency Status](https://gemnasium.com/badges/github.com/codegram/decidim.svg)](https://gemnasium.com/github.com/codegram/decidim)
 [![Issue Stats](http://issuestats.com/github/codegram/decidim/badge/pr?style=flat)](http://issuestats.com/github/codegram/decidim)


### PR DESCRIPTION
#### :tophat: What? Why?

This readds DroneCI after the several brainfarts we had. DroneCI is useful to double-check issues against a controlled CI. It's not specified as a required test to pass.

#### :ghost: GIF
![](https://media.giphy.com/media/MFKOGabPNbKxO/giphy.gif)