### PR TITLE
Readd projects Gemfile and ignore Gemfile.lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .byebug_history
 pkg/
 vendor/bundle
+decidim-*/Gemfile.lock

--- a/decidim-admin/Gemfile
+++ b/decidim-admin/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'decidim', path: '..'
+gemspec

--- a/decidim-core/Gemfile
+++ b/decidim-core/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'decidim', path: '..'
+gemspec

--- a/decidim-dev/Gemfile
+++ b/decidim-dev/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'decidim', path: '..'
+gemspec

--- a/decidim-system/Gemfile
+++ b/decidim-system/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'decidim', path: '..'
+gemspec


### PR DESCRIPTION
#### :tophat: What? Why?
We need Gemfiles if we need to create new migrations, as the rails binary tries to look for the file.

#### :ghost: GIF
![](https://media.giphy.com/media/uLrFuCTmyaSCA/giphy.gif)
