### PR TITLE
Support locale names with a dash. Closes #87

### DIFF
--- a/decidim-core/lib/decidim/translatable_attributes.rb
+++ b/decidim-core/lib/decidim/translatable_attributes.rb
@@ -27,7 +27,7 @@ module Decidim
         attribute name, Hash, default: {}
 
         locales.each do |locale|
-          attribute_name = "#{name}_#{locale}"
+          attribute_name = "#{name}_#{locale}".gsub("-", "__")
 
           attribute attribute_name, type, *options
 
@@ -60,7 +60,7 @@ module Decidim
         fields = arguments[0..-2]
 
         localized_fields = fields.flat_map do |f|
-          locales.map { |locale| "#{f}_#{locale}" }
+          locales.map { |locale| "#{f}_#{locale}".gsub("-", "__") }
         end
 
         validation_arguments = localized_fields + [options]
@@ -80,7 +80,8 @@ module Decidim
 
     def translatable_attribute_getter(name, locale)
       field = public_send(name) || {}
-      field[locale.to_s] || field[locale.to_sym]
+      corrected_locale = locale.to_s.gsub("__", "-")
+      field[corrected_locale] || field[corrected_locale.to_sym]
     end
   end
 end

--- a/decidim-core/spec/lib/translatable_attributes_spec.rb
+++ b/decidim-core/spec/lib/translatable_attributes_spec.rb
@@ -16,7 +16,7 @@ module Decidim
       end
     end
 
-    let(:available_locales) { %w(en ca) }
+    let(:available_locales) { %w(en ca pt-BR) }
 
     before do
       allow(I18n).to receive(:available_locales).and_return available_locales
@@ -32,18 +32,21 @@ module Decidim
       end
 
       it "creates a getter for each locale" do
-        model.name = { "en" => "Hello", "ca" => "Hola" }
+        model.name = { "en" => "Hello", "pt-BR" => "Olá", "ca" => "Hola" }
 
         expect(model.name_en).to eq("Hello")
         expect(model.name_ca).to eq("Hola")
+        expect(model.name_pt__BR).to eq("Olá")
       end
 
       it "creates a setter for each locale" do
         model.name_en = "Hello"
         model.name_ca = "Hola"
+        model.name_pt__BR = "Olá"
 
         expect(model.name).to include("en" => "Hello")
         expect(model.name).to include("ca" => "Hola")
+        expect(model.name).to include("pt-BR" => "Olá")
       end
 
       it "coerces values" do
@@ -67,11 +70,17 @@ module Decidim
       it "validates the presence in each locale" do
         model.name_en = "Hola"
         model.description_ca = "Una descripció mooooolt llarga"
+        model.summary_pt__BR = "Um resumo"
 
         expect(model.valid?).to eq(false)
 
-        expect(model.errors).to include(:name_ca, :summary_en, :summary_ca, :description_ca)
-        expect(model.errors).to_not include(:name_en, :description_en)
+        expect(model.errors).to include(
+          :name_ca,
+          :name_pt__BR,
+          :summary_en,
+          :summary_ca,
+        )
+        expect(model.errors).to_not include(:name_en, :description_en, :description_pt__BR)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
When a locale uses a dialect (`zn-CH` or `pt-BR` for example), the `TranslatableAttributes` module breaks. This PR fixes this bug, reported in #87.

#### :ghost: GIF
![](https://media.giphy.com/media/11WytEO5nVGkNO/giphy.gif)
