### PR TITLE
Localise emails. Closes #45

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ PATH
       decidim-core (= 0.0.1.alpha4)
       decidim-system (= 0.0.1.alpha4)
       rails (~> 5.0.0)
+      rails-i18n (~> 5.0.0)
 
 PATH
   remote: decidim-admin
@@ -268,6 +269,9 @@ GEM
       nokogiri (~> 1.6.0)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-i18n (5.0.1)
+      i18n (~> 0.7)
+      railties (~> 5.0)
     railties (5.0.0.1)
       actionpack (= 5.0.0.1)
       activesupport (= 5.0.0.1)

--- a/decidim-core/app/mailers/concerns/decidim/localised_mailer.rb
+++ b/decidim-core/app/mailers/concerns/decidim/localised_mailer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # A module to be included in mailers that changes the default behaviour so
+  # the emails are rendered in the user's locale instead of the default one.
+  module LocalisedMailer
+    extend ActiveSupport::Concern
+
+    included do
+      # Yields with the I18n locale changed to the user's one.
+      #
+      # Returns nothing.
+      def with_user(user)
+        I18n.with_locale(user.locale || I18n.locale) do
+          yield
+        end
+      end
+
+      # Overwrite default devise_mail method to always render the email with
+      # the user's locale.
+      def devise_mail(record, action, opts = {})
+        with_user(record) do
+          super
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/app/mailers/decidim/decidim_devise_mailer.rb
+++ b/decidim-core/app/mailers/decidim/decidim_devise_mailer.rb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 module Decidim
   # A custom mailer for Devise so we can tweak the invitation instructions for
-  # each role.
+  # each role and use a localised version.
   class DecidimDeviseMailer < Devise::Mailer
-    def invitation_instructions(record, token, opts = {})
-      @token = token
-      devise_mail(record, opts[:invitation_instructions] || :invitation_instructions, opts)
+    include LocalisedMailer
+    # Sends an email with the invitation instructions to a new user.
+    #
+    # user  - The User that has been invited.
+    # token - The String to be sent as a token to verify the invitation.
+    # opts  - A Hash with options to send the email (optional).
+    def invitation_instructions(user, token, opts = {})
+      with_user(user) do
+        @token = token
+
+        if opts[:invitation_instructions] == "organization_admin_invitation_instructions"
+          opts[:subject] = I18n.t("devise.mailer.organization_admin_invitation_instructions.subject", organization: user.organization.name)
+        end
+
+        devise_mail(user, opts[:invitation_instructions] || :invitation_instructions, opts)
+      end
     end
   end
 end

--- a/decidim-core/config/i18n-tasks.yml
+++ b/decidim-core/config/i18n-tasks.yml
@@ -89,6 +89,7 @@ ignore_missing:
 ## Consider these keys used:
 ignore_unused:
   - '{time.formats}.*'
+  - devise.mailer.password_change.subject
 # - 'activerecord.attributes.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -17,6 +17,12 @@ ca:
           Si no vols acceptar la invitació, ignora aquest correu.<br />
           El teu compte no es crearà fins que no accedeixis a l'enllaç de sota i triïs la teva contrasenya.
         someone_invited_you: Algú t'ha convidat a %{application}, pots acceptar la invitació amb l'enllaç a continuació.
+      organization_admin_invitation_instructions:
+        subject: T'han convidat a administrar %{organization}
+      password_change:
+        greeting: Hola %{recipient}!
+        message: Ens posem en contacte amb tu per notificar-te que la teva contrasenya ha estat canviada correctament.
+        subject: Contrasenya canviada
   layouts:
     decidim:
       footer:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -17,6 +17,8 @@ en:
           If you don't want to accept the invitation, please ignore this email.<br />
           Your account won't be created until you access the link above and set your password.
         someone_invited_you: Someone has invited you to %{application}, you can accept it through the link below.
+      organization_admin_invitation_instructions:
+        subject: You've been invited to admin %{organization}
   layouts:
     decidim:
       footer:

--- a/decidim-core/config/locales/es.yml
+++ b/decidim-core/config/locales/es.yml
@@ -7,6 +7,22 @@ es:
         welcome: Bienvenido/da %{organization}!
     menu:
       home: Inicio
+  devise:
+    mailer:
+      invitation_instructions:
+        accept: Aceptar invitación
+        accept_until: Esta invitación caducará el día %{due_date}.
+        hello: Hola %{email}
+        ignore: |-
+          Si no quieres aceptar la invitación ignora este correo.<br />
+          Tu cuenta no se creará hasta que accedas al enlance de abajo y escojas tu contraseña.
+        someone_invited_you: Alguien te ha invitado a %{application}, puedes aceptar la invitación con el enlace a continuación.
+      organization_admin_invitation_instructions:
+        subject: Te han invitado a administrar %{organization}
+      password_change:
+        greeting: "¡Hola %{recipient}!"
+        message: Nos ponemos en contacto contigo para notificarte que tu contraseña ha sido cambiada correctamente.
+        subject: Contraseña cambiada
   layouts:
     decidim:
       footer:

--- a/decidim-core/spec/mailers/decidim_devise_mailer_spec.rb
+++ b/decidim-core/spec/mailers/decidim_devise_mailer_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+
+RSpec.shared_examples "localised email" do
+  let(:user) { build(:user, locale: locale ) }
+
+  context "when the user has a custom locale" do
+    let(:locale) { "ca" }
+
+    it "uses the user's locale" do
+      expect(mail.subject).to eq(subject)
+      expect(mail.body.encoded).to match(body)
+    end
+  end
+
+  context "otherwise" do
+    let(:locale) { nil }
+
+    it "uses the default locale" do
+      expect(mail.subject).to eq(default_subject)
+      expect(mail.body.encoded).to match(default_body)
+    end
+  end
+end
+
+module Decidim
+  describe DecidimDeviseMailer, type: :mailer do
+    describe "confirmation_instructions" do
+      let(:mail) { described_class.confirmation_instructions(user, "foo", {}) }
+
+      let(:subject) { "Instruccions de confirmació" }
+      let(:body) { "Pots confirmar el correu electrònic del teu compte" }
+      let(:default_subject) {"Confirmation instructions"}
+      let(:default_body) {"You can confirm your account email through the link below"}
+
+      include_examples "localised email"
+    end
+
+    describe "reset_password_instructions" do
+      let(:mail) { described_class.reset_password_instructions(user, "foo", {}) }
+
+      let(:subject) { "Instruccions de regeneració de contrasenya" }
+      let(:body) { "Algú ha sol·licitat un enllaç per a canviar la teva contrasenya" }
+      let(:default_subject) {"Reset password instructions"}
+      let(:default_body) {"Someone has requested a link to change your password"}
+
+      include_examples "localised email"
+    end
+
+    describe "password_change" do
+      let(:mail) { described_class.password_change(user, {}) }
+
+      let(:subject) { "Contrasenya canviada" }
+      let(:body) { "Ens posem en contacte amb tu per notificar-te que la teva contrasenya ha estat canviada correctament" }
+      let(:default_subject) {"Password Changed"}
+      let(:default_body) {"contacting you to notify you that your password has been changed"}
+
+      include_examples "localised email"
+    end
+
+    describe "invitation_instructions" do
+      let(:mail) do
+        user.invitation_created_at = Time.current
+        described_class.invitation_instructions(user, "foo", {invitation_instructions: "organization_admin_invitation_instructions"})
+      end
+
+      let(:subject) { "T'han convidat a administrar #{user.organization.name}" }
+      let(:body) { "Acceptar invitaci" }
+      let(:default_subject) {"You've been invited to admin #{user.organization.name}"}
+      let(:default_body) {"Accept invitation"}
+
+      include_examples "localised email"
+    end
+  end
+end

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "decidim-system", Decidim.version
   spec.add_dependency "decidim-admin", Decidim.version
   spec.add_dependency "rails", Decidim.rails_version
+  spec.add_dependency "rails-i18n", Decidim.rails_version
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 11.0"


### PR DESCRIPTION
#### :tophat: What? Why?

Implements #45, also adds `rails-i18n` so we have translations for default Rails strings.

#### :dart: Acceptance criteria?

Mails are sent in the receivei's locale.

#### :ghost: GIF
![](https://i.imgur.com/EjMeZco.gif)