### PR TITLE
Add overridable logo partial

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_header.html.erb
@@ -21,21 +21,7 @@
         <div class="title-bar">
           <div class="row topbar">
             <div class="logo-wrapper">
-              <a href="/">
-                <!-- Remove this, use the final SVG logo -->
-                <span><%= current_organization.name %></span>
-                <style>
-                 .logo-wrapper span{ color: white; font-weight: 600;
-                   font-size: 1.4em;
-                   display: inline-block; text-align: left;
-                   padding-left: 8px; line-height: 1;
-                   position: relative; }
-                 .logo-wrapper span:before{ content: ""; display: block;
-                   position: absolute; border-left: 4px solid white; height: 88%;
-                   top: 6%; left: 0; }
-                </style>
-                <!-- /Remove-->
-              </a>
+              <%= render partial: "layouts/decidim/logo" %>
             </div>
             <div class="topbar__dropmenu language-choose">
               <ul class="dropdown menu" data-dropdown-menu>

--- a/decidim-core/app/views/layouts/decidim/_logo.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_logo.html.erb
@@ -1,0 +1,15 @@
+<%= link_to root_path do %>
+  <!-- Remove this, use the final SVG logo -->
+  <span><%= current_organization.name %></span>
+  <style>
+    .logo-wrapper span{ color: white; font-weight: 600;
+      font-size: 1.4em;
+      display: inline-block; text-align: left;
+      padding-left: 8px; line-height: 1;
+      position: relative; }
+    .logo-wrapper span:before{ content: ""; display: block;
+      position: absolute; border-left: 4px solid white; height: 88%;
+      top: 6%; left: 0; }
+  </style>
+  <!-- /Remove-->
+<% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

By splitting the logo into a separate file, we allow the third-party developers to override the view for its own needs.

#### :ghost: GIF
![](https://media.giphy.com/media/l2Sq4BwB0DSpDCkve/giphy.gif)
