### PR TITLE
Fix FormBuilder

### DIFF
--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -17,7 +17,7 @@ module Decidim
         label = options[:label] || label_for(name)
         language = locale
 
-        send(type, "#{name}_#{locale}", options.merge(label: "#{label} (#{language})"))
+        send(type, "#{name}_#{locale.to_s.gsub("-", "__")}", options.merge(label: "#{label} (#{language})"))
       end.join.html_safe
     end
 

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -21,7 +21,7 @@ module Decidim
     end
 
     before do
-      allow(I18n).to receive(:available_locales).and_return %w(ca en)
+      allow(I18n).to receive(:available_locales).and_return %w(ca en de-CH)
     end
 
     let(:builder) { FormBuilder.new(:resource, resource, helper, {}) }
@@ -35,9 +35,11 @@ module Decidim
 
       expect(parsed.css("textarea[name='resource[name_en]']").first).to be
       expect(parsed.css("textarea[name='resource[name_en]']").first).to be
+      expect(parsed.css("textarea[name='resource[name_de__CH]']").first).to be
 
       expect(parsed.css("label[for='resource_name_en']").first).to be
       expect(parsed.css("label[for='resource_name_ca']").first).to be
+      expect(parsed.css("label[for='resource_name_de__CH']").first).to be
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes `FormBuilder` so it works with composed locales with a dash (-).

#### :ghost: GIF
![](https://media.giphy.com/media/5WDrPMzEqPGve/giphy.gif)