### PR TITLE
Run the CI against Ruby 2.4.0 allowing failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,18 @@ env:
 
 before_install:
   - export BUNDLE_GEMFILE="$TRAVIS_BUILD_DIR/Gemfile"
-  - cd $GEM; 
+  - cd $GEM;
 
 script:
   - $TRAVIS_BUILD_DIR/run_ci.sh
 
 rvm:
   - 2.3.1
+  - 2.4.0-preview1
 
 notifications:
     email: false
+
+matrix:
+  allow_failures:
+  - rvm: 2.4.0-preview1

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-ruby "2.3.1"
-
 gemspec path: "."
 gemspec path: "decidim-core"
 gemspec path: "decidim-system"

--- a/decidim-dev/lib/decidim/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/test/base_spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 ENV["RAILS_ENV"] ||= "test"
 
-if ENV["CI"]
+if ENV["CI"] && ENV["TRAVIS_RUBY_VERSION"] != "2.4.0-preview1"
   require "simplecov"
   SimpleCov.start
 


### PR DESCRIPTION
#### :tophat: What? Why?

I think it's useful to test against future Ruby versions so we know we can upgrade in a near future.

#### :dart: Acceptance criteria?

TravisCI runs the suite against Ruby 2.4.0.

#### :ghost: GIF
![](http://i.imgur.com/gTBZMVS.gif)
