### PR TITLE
Use :long time format for invitation instructions

### DIFF
--- a/decidim-core/app/views/devise/mailer/organization_admin_invitation_instructions.html.erb
+++ b/decidim-core/app/views/devise/mailer/organization_admin_invitation_instructions.html.erb
@@ -4,7 +4,7 @@
 <p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token, invite_redirect: decidim_admin.root_path, host: @resource.organization.host) %></p>
 
 <% if @resource.invitation_due_at %>
-  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
+  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :long)) %></p>
 <% end %>
 
 <p><%= t("devise.mailer.invitation_instructions.ignore").html_safe %></p>

--- a/decidim-core/app/views/devise/mailer/organization_admin_invitation_instructions.text.erb
+++ b/decidim-core/app/views/devise/mailer/organization_admin_invitation_instructions.text.erb
@@ -5,7 +5,7 @@
 <%= accept_invitation_url(@resource, invitation_token: @token, invite_redirect: decidim_admin.root_path, host: @resource.organization.host) %>
 
 <% if @resource.invitation_due_at %>
-  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
+  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :long)) %>
 <% end %>
 
 <%= strip_tags t("devise.mailer.invitation_instructions.ignore") %>

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -66,9 +66,3 @@ ca:
     home:
       register: Registra't
       welcome: Benvingut/da a %{organization}!
-  time:
-    formats:
-      devise:
-        mailer:
-          invitation_instructions:
-            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -62,9 +62,3 @@ en:
     home:
       register: Register
       welcome: Welcome to %{organization}!
-  time:
-    formats:
-      devise:
-        mailer:
-          invitation_instructions:
-            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/decidim-core/config/locales/es.yml
+++ b/decidim-core/config/locales/es.yml
@@ -66,9 +66,3 @@ es:
     home:
       register: Regístrate
       welcome: Bienvenido/da %{organization}!
-  time:
-    formats:
-      devise:
-        mailer:
-          invitation_instructions:
-            accept_until_format: "% B% d,% Y% I:% M% p"


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes #104.

It's nearly the sime as the one at devise-invitable and we avoid having to overwrite the time.formats scope.

#### :dart: Acceptance criteria?

`time.formats.short` translation is available in all locales.

#### :ghost: GIF
![](http://i.imgur.com/0rzzRw6.gif)