### PR TITLE
Add custom error pages

### DIFF
--- a/decidim-core/app/views/pages/404.html.erb
+++ b/decidim-core/app/views/pages/404.html.erb
@@ -1,0 +1,13 @@
+<main class="wrapper">
+  <div class="row">
+    <div class="large-8 large-centered">
+      <div class="static__message">
+        <h1 class="heading1 page-title"><%= t(".title") %></h1>
+        <p><%= t(".content_doesnt_exist") %></p>
+        <div class="static__message__cta">
+          <%= link_to t(".back_home"), root_path, class: "button" %>
+        </div>
+      </div>
+  </div>
+</div>
+</main>

--- a/decidim-core/app/views/pages/500.html.erb
+++ b/decidim-core/app/views/pages/500.html.erb
@@ -1,0 +1,10 @@
+<main class="wrapper">
+  <div class="row">
+    <div class="large-8 large-centered">
+    <div class="static__message">
+      <h1 class="heading1 page-title"><%= t(".title") %></h1>
+      <p><%= t(".try_later") %></p>
+    </div>
+  </div>
+</div>
+</main>

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -81,6 +81,13 @@ ca:
     en: English
     es: Castellano
   pages:
+    '404':
+      back_home: Tornar a l'inici
+      content_doesnt_exist: Aquesta adreça és incorrecta o ha estat eliminada.
+      title: No s'ha trobat la pàgina que busques!
+    '500':
+      title: Hi ha hagut un problema amb el nostre servidor
+      try_later: Si us plau, torna-ho a intentar més tard.
     home:
       register: Registra't
       welcome: Benvingut/da a %{organization}!

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -77,6 +77,13 @@ en:
     en: English
     es: Castellano
   pages:
+    '404':
+      back_home: Back home
+      content_doesnt_exist: This address is incorrect or has been removed.
+      title: The page you're looking for can't be found
+    '500':
+      title: There was a problem with our server
+      try_later: Please try again later.
     home:
       register: Register
       welcome: Welcome to %{organization}!

--- a/decidim-core/config/locales/es.yml
+++ b/decidim-core/config/locales/es.yml
@@ -81,6 +81,13 @@ es:
     en: English
     es: Castellano
   pages:
+    '404':
+      back_home: Volver al inicio
+      content_doesnt_exist: Esta dirección es incorrecta o ha sido eliminada.
+      title: "¡No se ha encontrado la página que buscas!"
+    '500':
+      title: Ha habido un problema con nuestro servidor
+      try_later: Por favor, vuelve a intentarlo más tarde.
     home:
       register: Regístrate
       welcome: Bienvenido/da %{organization}!

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -17,5 +17,9 @@ Decidim::Core::Engine.routes.draw do
   resources :participatory_processes, only: [:index, :show]
 
   get "/pages/*id" => "pages#show", as: :page, format: false
+
+  match "/404", to: "pages#show", id: "404", via: :all
+  match "/500", to: "pages#show", id: "500", via: :all
+
   root to: "pages#show", id: "home"
 end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -51,6 +51,10 @@ module Decidim
       initializer "decidim.default_form_builder" do |_app|
         ActionView::Base.default_form_builder = Decidim::FormBuilder
       end
+
+      initializer "decidim.exceptions_app" do |app|
+        app.config.exceptions_app = Decidim::Core::Engine.routes
+      end
     end
   end
 end

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -77,6 +77,11 @@ module Decidim
         ]
       end
 
+      def remove_default_error_pages
+        remove_file "public/404.html"
+        remove_file "public/500.html"
+      end
+
       private
 
       def get_builder_class


### PR DESCRIPTION
#### :tophat: What? Why?

Implements #111. I localised these pages using the locales instead of custom templates for each locale because if a template is missign for the current locale Rails throws a 500 error, which is a bit inconvenient when rendering error pages.

#### :dart: Acceptance criteria?

Going to http://localhost:3000/500 and http://localhost:3000/404 render the error pages, the same when raising 500 or 404 errors.

#### :ghost: GIF
![](http://i.imgur.com/qtPZZdh.gif)
