### PR TITLE
Raise an error on missing translations in test environments

### DIFF
--- a/decidim-dev/lib/generators/decidim/dummy_generator.rb
+++ b/decidim-dev/lib/generators/decidim/dummy_generator.rb
@@ -43,6 +43,10 @@ module Decidim
         end
       end
 
+      def raise_on_missing_translations
+        gsub_file "#{dummy_path}/config/environments/test.rb", "# config.action_view.raise_on_missing_translations", " config.action_view.raise_on_missing_translations"
+      end
+
       private
 
       def dummy_path


### PR DESCRIPTION
#### :tophat: What? Why?

To avoid possible errors we should always raise an error when there's a missing translation.

#### :ghost: GIF
![](http://i.imgur.com/lmNA5.gif)
