### PR TITLE
Add participatory process steps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ PATH
   specs:
     decidim-core (0.0.1.alpha7)
       active_link_to (~> 1.0.0)
+      date_validator (~> 0.9.0)
       devise (~> 4.2)
       devise-i18n (~> 1.1.0)
       foundation-rails (~> 6.2.3.0)
@@ -169,6 +170,9 @@ GEM
     css_parser (1.4.5)
       addressable
     database_cleaner (1.5.3)
+    date_validator (0.9.0)
+      activemodel
+      activesupport
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (4.2.0)
@@ -412,4 +416,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.2
+   1.13.4

--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process_step.rb
@@ -36,8 +36,8 @@ module Decidim
           title: form.title,
           description: form.description,
           short_description: form.short_description,
-          start_date: form.start_date,
-          end_date: form.end_date,
+          start_date: form.start_date.at_midnight,
+          end_date: form.end_date.at_midnight,
           participatory_process: @participatory_process
         )
       end

--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process_step.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A command with all the business logic when creating a new participatory
+    # process in the system.
+    class CreateParticipatoryProcessStep < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # form - A form object with the params.
+      # participatory_process - The ParticipatoryProcess that will hold the
+      #   step
+      def initialize(form, participatory_process)
+        @form = form
+        @participatory_process = participatory_process
+      end
+
+      # Executes the command. Braodcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        create_participatory_process_step
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :form
+
+      def create_participatory_process_step
+        ParticipatoryProcessStep.create!(
+          title: form.title,
+          description: form.description,
+          short_description: form.short_description,
+          start_date: form.start_date,
+          end_date: form.end_date,
+          participatory_process: @participatory_process
+        )
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/update_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_participatory_process_step.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A command with all the business logic when creating a new participatory
+    # process in the system.
+    class UpdateParticipatoryProcessStep < Rectify::Command
+      attr_reader :participatory_process_step
+      # Public: Initializes the command.
+      #
+      # participatory_process_step - the ParticipatoryProcessStep to update
+      # form - A form object with the params.
+      def initialize(participatory_process_step, form)
+        @participatory_process_step = participatory_process_step
+        @form = form
+      end
+
+      # Executes the command. Braodcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        update_participatory_process_step
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :form
+
+      def update_participatory_process_step
+        participatory_process_step.update_attributes!(attributes)
+      end
+
+      def attributes
+        {
+          title: form.title,
+          start_date: form.start_date,
+          end_date: form.end_date,
+          description: form.description,
+          short_description: form.short_description
+        }
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/concerns/decidim/needs_authorization.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/needs_authorization.rb
@@ -29,12 +29,14 @@ module Decidim
       #
       # record - the record that will be evaluated against the policy class.
       def policy(record)
-        policies[record] ||= policy_class.new(current_user, record)
+        policies[record] ||= policy_class(record).new(current_user, record)
       end
 
       # Needed in order to make the `policy` method work. Overwirite it in the
       # given controller and make it return a Policy class.
-      def policy_class
+      #
+      # _record - The record that will be evaluated against the policy class.
+      def policy_class(_record)
         raise NotImplementedError, "Define this method and make it return a policy class name in order to make it work"
       end
 

--- a/decidim-admin/app/controllers/decidim/admin/dashboard_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/dashboard_controller.rb
@@ -12,7 +12,7 @@ module Decidim
 
       private
 
-      def policy_class
+      def policy_class(_record)
         Decidim::Admin::DashboardPolicy
       end
     end

--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_steps_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_steps_controller.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+require_dependency "decidim/admin/application_controller"
+
+module Decidim
+  module Admin
+    # Controller that allows managing all the Admins.
+    #
+    class ParticipatoryProcessStepsController < ApplicationController
+      def new
+        @form = ParticipatoryProcessStepForm.new
+        authorize ParticipatoryProcessStep
+      end
+
+      def create
+        @form = ParticipatoryProcessStepForm.from_params(params)
+        authorize ParticipatoryProcessStep
+
+        CreateParticipatoryProcessStep.call(@form, participatory_process) do
+          on(:ok) do
+            flash[:notice] = I18n.t("participatory_process_steps.create.success", scope: "decidim.admin")
+            redirect_to participatory_process_path(participatory_process)
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("participatory_process_steps.create.error", scope: "decidim.admin")
+            render :new
+          end
+        end
+      end
+
+      def edit
+        @participatory_process_step = collection.find(params[:id])
+        authorize @participatory_process_step
+        @form = ParticipatoryProcessStepForm.from_model(@participatory_process_step)
+      end
+
+      def update
+        @participatory_process_step = collection.find(params[:id])
+        authorize @participatory_process_step
+        @form = ParticipatoryProcessStepForm.from_params(params)
+
+        UpdateParticipatoryProcessStep.call(@participatory_process_step, @form) do
+          on(:ok) do
+            flash[:notice] = I18n.t("participatory_process_steps.update.success", scope: "decidim.admin")
+            redirect_to participatory_process_path(participatory_process)
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("participatory_process_steps.update.error", scope: "decidim.admin")
+            render :edit
+          end
+        end
+      end
+
+      def show
+        @participatory_process_step = collection.find(params[:id])
+        authorize @participatory_process_step
+      end
+
+      def destroy
+        @participatory_process_step = collection.find(params[:id])
+        authorize @participatory_process_step
+
+        @participatory_process_step.destroy!
+
+        flash[:notice] = I18n.t("participatory_process_steps.destroy.success", scope: "decidim.admin")
+
+        redirect_to participatory_process_path(@participatory_process_step.participatory_process)
+      end
+
+      private
+
+      def participatory_process
+        current_organization.participatory_processes.find(params[:participatory_process_id])
+      end
+
+      def collection
+        participatory_process.steps
+      end
+
+      def policy_class(_record)
+        Decidim::Admin::ParticipatoryProcessPolicy
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
@@ -79,7 +79,7 @@ module Decidim
         current_organization.participatory_processes
       end
 
-      def policy_class
+      def policy_class(_record)
         Decidim::Admin::ParticipatoryProcessPolicy
       end
     end

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_step_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_step_form.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A form object used to create participatory processes steps from the admin
+    # dashboard.
+    #
+    class ParticipatoryProcessStepForm < Rectify::Form
+      include TranslatableAttributes
+
+      translatable_attribute :title, String
+      translatable_attribute :description, String
+      translatable_attribute :short_description, String
+
+      mimic :participatory_process_step
+
+      attribute :start_date, DateTime
+      attribute :end_date, DateTime
+
+      translatable_validates :title, :description, :short_description, presence: true
+    end
+  end
+end

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_step_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_step_form.rb
@@ -18,18 +18,8 @@ module Decidim
 
       translatable_validates :title, :description, :short_description, presence: true
 
-      validate :end_date, :dates_order
-
-      private
-
-      def dates_order
-        return if end_date > start_date
-
-        errors.add(
-          :end_date,
-          I18n.t("models.participatory_process_step.validations.dates_order", scope: "decidim.admin")
-        )
-      end
+      validates :start_date, date: { before: :end_date, allow_blank: true, if: proc { |obj| obj.end_date.present? } }
+      validates :end_date, date: { after: :start_date, allow_blank: true, if: proc { |obj| obj.start_date.present? } }
     end
   end
 end

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_step_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_step_form.rb
@@ -17,6 +17,19 @@ module Decidim
       attribute :end_date, DateTime
 
       translatable_validates :title, :description, :short_description, presence: true
+
+      validate :end_date, :dates_order
+
+      private
+
+      def dates_order
+        return if end_date > start_date
+
+        errors.add(
+          :end_date,
+          I18n.t("models.participatory_process_step.validations.dates_order", scope: "decidim.admin")
+        )
+      end
     end
   end
 end

--- a/decidim-admin/app/policies/decidim/admin/participatory_process_policy.rb
+++ b/decidim-admin/app/policies/decidim/admin/participatory_process_policy.rb
@@ -24,11 +24,7 @@ module Decidim
       def index?
         return true if record.empty?
 
-        if record.first.is_a?(Decidim::ParticipatoryProcessStep)
-          return user.roles.include?("admin") && user.organization == record.first.participatory_process.organization
-        end
-
-        user.roles.include?("admin") && user.organization == record.first.organization
+        check_admin_and_organization(record.first)
       end
 
       # Checks if the user can see a participatory process.
@@ -61,12 +57,10 @@ module Decidim
 
       private
 
-      def check_admin_and_organization
-        if record.is_a?(Decidim::ParticipatoryProcessStep)
-          return user.roles.include?("admin") && user.organization == record.participatory_process.organization
-        end
+      def check_admin_and_organization(record_to_validate = nil)
+        record_to_validate ||= record
 
-        user.roles.include?("admin") && user.organization == record.organization
+        user.roles.include?("admin") && user.organization == record_to_validate.organization
       end
     end
   end

--- a/decidim-admin/app/policies/decidim/admin/participatory_process_policy.rb
+++ b/decidim-admin/app/policies/decidim/admin/participatory_process_policy.rb
@@ -35,39 +35,33 @@ module Decidim
       #
       # Returns a Boolean.
       def show?
-        if record.is_a?(Decidim::ParticipatoryProcessStep)
-          return user.roles.include?("admin") && user.organization == record.participatory_process.organization
-        end
-
-        user.roles.include?("admin") && user.organization == record.organization
+        check_admin_and_organization
       end
 
       # Checks if the user can edit a participatory process.
       #
       # Returns a Boolean.
       def edit?
-        if record.is_a?(Decidim::ParticipatoryProcessStep)
-          return user.roles.include?("admin") && user.organization == record.participatory_process.organization
-        end
-
-        user.roles.include?("admin") && user.organization == record.organization
+        check_admin_and_organization
       end
 
       # Checks if the user can update a participatory process.
       #
       # Returns a Boolean.
       def update?
-        if record.is_a?(Decidim::ParticipatoryProcessStep)
-          return user.roles.include?("admin") && user.organization == record.participatory_process.organization
-        end
-
-        user.roles.include?("admin") && user.organization == record.organization
+        check_admin_and_organization
       end
 
       # Checks if the user can destroy a participatory process.
       #
       # Returns a Boolean.
       def destroy?
+        check_admin_and_organization
+      end
+
+      private
+
+      def check_admin_and_organization
         if record.is_a?(Decidim::ParticipatoryProcessStep)
           return user.roles.include?("admin") && user.organization == record.participatory_process.organization
         end

--- a/decidim-admin/app/policies/decidim/admin/participatory_process_policy.rb
+++ b/decidim-admin/app/policies/decidim/admin/participatory_process_policy.rb
@@ -2,7 +2,7 @@
 module Decidim
   module Admin
     # A policy to define all the authorizations regarding a
-    # ParticipatoryProcess, to be used with Pundit.
+    # ParticipatoryProcess and its related steps, to be used with Pundit.
     class ParticipatoryProcessPolicy < ApplicationPolicy
       # Checks if the user can see the form for participatory process creation.
       #
@@ -22,6 +22,12 @@ module Decidim
       #
       # Returns a Boolean.
       def index?
+        return true if record.empty?
+
+        if record.first.is_a?(Decidim::ParticipatoryProcessStep)
+          return user.roles.include?("admin") && user.organization == record.first.participatory_process.organization
+        end
+
         user.roles.include?("admin") && user.organization == record.first.organization
       end
 
@@ -29,6 +35,10 @@ module Decidim
       #
       # Returns a Boolean.
       def show?
+        if record.is_a?(Decidim::ParticipatoryProcessStep)
+          return user.roles.include?("admin") && user.organization == record.participatory_process.organization
+        end
+
         user.roles.include?("admin") && user.organization == record.organization
       end
 
@@ -36,6 +46,10 @@ module Decidim
       #
       # Returns a Boolean.
       def edit?
+        if record.is_a?(Decidim::ParticipatoryProcessStep)
+          return user.roles.include?("admin") && user.organization == record.participatory_process.organization
+        end
+
         user.roles.include?("admin") && user.organization == record.organization
       end
 
@@ -43,6 +57,10 @@ module Decidim
       #
       # Returns a Boolean.
       def update?
+        if record.is_a?(Decidim::ParticipatoryProcessStep)
+          return user.roles.include?("admin") && user.organization == record.participatory_process.organization
+        end
+
         user.roles.include?("admin") && user.organization == record.organization
       end
 
@@ -50,6 +68,10 @@ module Decidim
       #
       # Returns a Boolean.
       def destroy?
+        if record.is_a?(Decidim::ParticipatoryProcessStep)
+          return user.roles.include?("admin") && user.organization == record.participatory_process.organization
+        end
+
         user.roles.include?("admin") && user.organization == record.organization
       end
     end

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/_form.html.erb
@@ -1,0 +1,19 @@
+<div class="field">
+  <%= form.translated :text_field, :title, autofocus: true %>
+</div>
+
+<div class="field">
+  <%= form.translated :text_area, :short_description %>
+</div>
+
+<div class="field">
+  <%= form.translated :text_area, :description %>
+</div>
+
+<div class="field">
+  <%= form.date_field :start_date %>
+</div>
+
+<div class="field">
+  <%= form.date_field :end_date %>
+</div>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/edit.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  <h2><%= t ".title" %></h2>
+<% end %>
+
+<%= form_for(@form, url: participatory_process_step_path(@participatory_process_step.participatory_process, @participatory_process_step)) do |f| %>
+  <%= render partial: 'form', object: f %>
+
+  <div class="actions">
+    <%= f.submit t(".update") %>
+  </div>
+<% end %>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/new.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  <h2><%= t ".title" %></h2>
+<% end %>
+
+<%= form_for(@form) do |f| %>
+  <%= render partial: 'form', object: f %>
+
+  <div class="actions">
+    <%= f.submit t(".create") %>
+  </div>
+<% end %>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/show.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title do %>
+  <h2><%= link_to translated_attribute(@participatory_process_step.participatory_process.title), @participatory_process_step.participatory_process %></h2>
+  <h3 class="subheader"><%= translated_attribute(@participatory_process_step.title) %></h3>
+<% end %>
+
+<div class="actions">
+  <hr />
+  <%= link_to_if policy(@participatory_process_step).edit?, t("decidim.admin.actions.edit"), ['edit', @participatory_process_step] %>
+  <%= link_to_if policy(@participatory_process_step).destroy?, t("decidim.admin.actions.destroy"), @participatory_process_step, method: :delete, class: "alert button", data: { confirm: t("decidim.admin.actions.confirm_destroy") } %>
+</div>
+
+<dl>
+  <%= display_for @participatory_process_step,
+    :title,
+    :short_description,
+    :description
+    %>
+  <dt><%= display_label(@participatory_process_step, :start_date) %></dt>
+  <dd><%= l @participatory_process_step.start_date, format: :short %></dd>
+  <dt><%= display_label(@participatory_process_step, :end_date) %></dt>
+  <dd><%= l @participatory_process_step.end_date, format: :short %></dd>
+</dl>

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <div class="actions title">
-  <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.participatory_process.name", scope: "decidim.admin")), ['new', 'participatory_process'], class: 'new' %>
+  <%= link_to_if policy(@participatory_processes).new?, t("actions.new", scope: "decidim.admin", name: t("models.participatory_process.name", scope: "decidim.admin")), ['new', 'participatory_process'], class: 'new' %>
 </div>
 
 <table class="stack">

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/show.html.erb
@@ -25,3 +25,42 @@
   <dt><%= display_label(@participatory_process, :promoted) %></dt>
   <dd><%= humanize_boolean @participatory_process.promoted? %></dd>
 </dl>
+
+<% if policy(@participatory_process.steps).index? %>
+  <section id="steps">
+    <h4><%= t(".steps_title", scope: "decidim.admin") %></h4>
+    <div class="actions title">
+      <%= link_to_if policy(@participatory_process.steps).new?, t("actions.new", scope: "decidim.admin", name: t("models.participatory_process_step.name", scope: "decidim.admin")), new_participatory_process_step_path(@participatory_process), class: 'new' %>
+    </div>
+
+    <table class="stack">
+      <thead>
+        <tr>
+          <th><%= t("models.participatory_process_step.fields.title", scope: "decidim.admin") %></th>
+          <th><%= t("models.participatory_process_step.fields.start_date", scope: "decidim.admin") %></th>
+          <th><%= t("models.participatory_process_step.fields.end_date", scope: "decidim.admin") %></th>
+          <th class="actions"><%= t("actions.title", scope: "decidim.admin") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @participatory_process.steps.each do |step| %>
+          <tr>
+            <td>
+              <%= link_to translated_attribute(step.title), participatory_process_step_path(@participatory_process, step) %><br />
+            </td>
+            <td>
+              <%= l step.start_date, format: :short %>
+            </td>
+            <td>
+              <%= l step.end_date, format: :short %>
+            </td>
+            <td class="actions">
+              <%= link_to_if policy(step).edit?, t("actions.edit", scope: "decidim.admin"), edit_participatory_process_step_path(@participatory_process, step) %>
+              <%= link_to_if policy(step).destroy?, t("actions.destroy", scope: "decidim.admin"), participatory_process_step_path(@participatory_process, step), method: :delete, class: "small alert button", data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </section>
+<% end %>

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -56,7 +56,7 @@ ca:
       participatory_processes:
         create:
           error: S'ha produït un error en crear un nou procés participatiu.
-          success: El procés participatiu s'ha creat correctament.
+          success: El procés participatiu s'ha creat correctament. Continua ara amb la configuració de les fases.
         destroy:
           success: El procés participatiu s'ha eliminat correctament.
         edit:

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -36,6 +36,8 @@ ca:
             start_date: Data d'inici
             title: Títol
           name: Name
+          validations:
+            dates_order: La data de finalització ha de ser posterior a la data d'inici
       participatory_process_steps:
         create:
           error: S'ha produït un error en crear una nova fase de procés participatiu.

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -36,8 +36,6 @@ ca:
             start_date: Data d'inici
             title: Títol
           name: Name
-          validations:
-            dates_order: La data de finalització ha de ser posterior a la data d'inici
       participatory_process_steps:
         create:
           error: S'ha produït un error en crear una nova fase de procés participatiu.

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -13,6 +13,11 @@ ca:
         new: Nou %{name}
         title: Accions
         unauthorized: No tens permís per realitzar aquesta acció.
+      decidim:
+        admin:
+          participatory_processes:
+            show:
+              steps_title: Fases
       menu:
         dashboard: Tauler de control
         participatory_processes: Processos participatius
@@ -25,6 +30,27 @@ ca:
           name: Procés participatiu
           validations:
             slug_uniqueness: Ja existeix un altre procés participatiu amb el mateix identificador
+        participatory_process_step:
+          fields:
+            end_date: Data de finalització
+            start_date: Data d'inici
+            title: Títol
+          name: Name
+      participatory_process_steps:
+        create:
+          error: S'ha produït un error en crear una nova fase de procés participatiu.
+          success: La fase de procés participatiu s'ha creat correctament.
+        destroy:
+          success: La fase de procés participatiu s'ha eliminat correctament.
+        edit:
+          title: Editar fase de procés participatiu
+          update: Actualitzar fase de procés participatiu
+        new:
+          create: Crear fase de procés participatiu
+          title: Nova fase de procés participatiu
+        update:
+          error: S'ha produït un error en l'actualització d'aquesta fase de procés participatiu.
+          success: La fase de procés participatiu s'ha actualitzat correctament.
       participatory_processes:
         create:
           error: S'ha produït un error en crear un nou procés participatiu.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -36,8 +36,6 @@ en:
             start_date: Start date
             title: Title
           name: Participatory process step
-          validations:
-            dates_order: End date must be after start date
       participatory_process_steps:
         create:
           error: There was an error creating a new participatory process step.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -13,6 +13,11 @@ en:
         new: New %{name}
         title: Actions
         unauthorized: You are not authorized to perform this action
+      decidim:
+        admin:
+          participatory_processes:
+            show:
+              steps_title: Steps
       menu:
         dashboard: Dashboard
         participatory_processes: Participatory processes
@@ -25,6 +30,27 @@ en:
           name: Participatory process
           validations:
             slug_uniqueness: Another participatory process with the same slug already exists
+        participatory_process_step:
+          fields:
+            end_date: End date
+            start_date: Start date
+            title: Title
+          name: Participatory process step
+      participatory_process_steps:
+        create:
+          error: There was an error creating a new participatory process step.
+          success: Participatory process step created successfully
+        destroy:
+          success: Participatory process step successfully destroyed
+        edit:
+          title: Edit participatory process step
+          update: Update participatory process step
+        new:
+          create: Create participatory process step
+          title: New participatory process step
+        update:
+          error: There was an error when updating this participatory process step.
+          success: Participatory process step updated successfully
       participatory_processes:
         create:
           error: There was an error creating a new participatory process.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -56,7 +56,7 @@ en:
       participatory_processes:
         create:
           error: There was an error creating a new participatory process.
-          success: Participatory process created successfully
+          success: Participatory process created successfully. Configure now its steps.
         destroy:
           success: Participatory process successfully destroyed
         edit:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -36,6 +36,8 @@ en:
             start_date: Start date
             title: Title
           name: Participatory process step
+          validations:
+            dates_order: End date must be after start date
       participatory_process_steps:
         create:
           error: There was an error creating a new participatory process step.

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -36,6 +36,8 @@ es:
             start_date: Fecha de inicio
             title: Título
           name: Fase de proceso participativo
+          validations:
+            dates_order: La fecha de finalización tiene que ser posterior a la fecha de inicio
       participatory_process_steps:
         create:
           error: Se ha producido un error al crear una nueva fase de proceso participativo.

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -56,7 +56,7 @@ es:
       participatory_processes:
         create:
           error: Se ha producido un error al crear un nuevo proceso participativo.
-          success: El proceso participativo se ha creado correctamente.
+          success: El proceso participativo se ha creado correctamente. Sigue ahora con la configuración de las fases.
         destroy:
           success: El proceso participativo se ha eliminado correctamente.
         edit:

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -7,12 +7,17 @@ es:
   decidim:
     admin:
       actions:
-        confirm_destroy: ¿Seguro que lo quieres eliminar?
+        confirm_destroy: "¿Seguro que lo quieres eliminar?"
         destroy: Eliminar
         edit: Editar
         new: Nuevo %{name}
         title: Acciones
         unauthorized: No tienes permiso para realizar esta acción.
+      decidim:
+        admin:
+          participatory_processes:
+            show:
+              steps_title: Fases
       menu:
         dashboard: Panel de control
         participatory_processes: Procesos participativos
@@ -25,6 +30,27 @@ es:
           name: Proceso participativo
           validations:
             slug_uniqueness: Ya existe otro proceso participativo con el mismo identificador
+        participatory_process_step:
+          fields:
+            end_date: Fecha de finalización
+            start_date: Fecha de inicio
+            title: Título
+          name: Fase de proceso participativo
+      participatory_process_steps:
+        create:
+          error: Se ha producido un error al crear una nueva fase de proceso participativo.
+          success: La fase de proceso participativo se ha creado correctamente.
+        destroy:
+          success: La fase de proceso participativo se ha eliminado correctamente.
+        edit:
+          title: Editar fase de proceso participativo
+          update: Actualizar fase de proceso participativo
+        new:
+          create: Crear fase de proceso participativo
+          title: Nuevo fase de proceso participativo
+        update:
+          error: Se ha producido un error en la actualización de esta fase de proceso participativo.
+          success: La fase de proceso participativo se ha actualizado correctamente.
       participatory_processes:
         create:
           error: Se ha producido un error al crear un nuevo proceso participativo.

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -36,8 +36,6 @@ es:
             start_date: Fecha de inicio
             title: Título
           name: Fase de proceso participativo
-          validations:
-            dates_order: La fecha de finalización tiene que ser posterior a la fecha de inicio
       participatory_process_steps:
         create:
           error: Se ha producido un error al crear una nueva fase de proceso participativo.

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 Decidim::Admin::Engine.routes.draw do
   constraints(->(request) { Decidim::Admin::OrganizationDashboardConstraint.new(request).matches? }) do
-    resources :participatory_processes
+    resources :participatory_processes do
+      resources :steps, controller: "participatory_process_steps", except: :index
+    end
     root to: "dashboard#show"
   end
 end

--- a/decidim-admin/spec/features/manage_participatory_process_steps_spec.rb
+++ b/decidim-admin/spec/features/manage_participatory_process_steps_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Manage participatory process steps", type: :feature do
+  let(:organization) { create(:organization) }
+  let(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:participatory_process) do
+    create(
+      :participatory_process,
+      organization: organization,
+      description: { en: "Description", ca: "Descripció", es: "Descripción" },
+      short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" }
+    )
+  end
+  let!(:process_step) do
+    create(
+      :participatory_process_step,
+      participatory_process: participatory_process,
+      description: { en: "Description", ca: "Descripció", es: "Descripción" },
+      short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" }
+    )
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+    visit decidim_admin.participatory_process_path(participatory_process)
+  end
+
+  it "displays all fields from a single participatory process" do
+    within "table" do
+      click_link process_step.title["en"]
+    end
+
+    within "dl" do
+      expect(page).to have_content(process_step.title["en"])
+      expect(page).to have_content(process_step.title["es"])
+      expect(page).to have_content(process_step.title["ca"])
+      expect(page).to have_content(process_step.short_description["en"])
+      expect(page).to have_content(process_step.short_description["es"])
+      expect(page).to have_content(process_step.short_description["ca"])
+      expect(page).to have_content(process_step.description["en"])
+      expect(page).to have_content(process_step.description["es"])
+      expect(page).to have_content(process_step.description["ca"])
+    end
+  end
+
+  it "creates a new participatory_process" do
+    find("#steps .actions .new").click
+
+    within ".new_participatory_process_step" do
+      fill_in :participatory_process_step_title_en, with: "My participatory process step"
+      fill_in :participatory_process_step_title_es, with: "Mi fase de proceso participativo"
+      fill_in :participatory_process_step_title_ca, with: "La meva fase de procés participatiu"
+      fill_in :participatory_process_step_short_description_en, with: "Short description"
+      fill_in :participatory_process_step_short_description_es, with: "Descripción corta"
+      fill_in :participatory_process_step_short_description_ca, with: "Descripció curta"
+      fill_in :participatory_process_step_description_en, with: "A longer description"
+      fill_in :participatory_process_step_description_es, with: "Descripción más larga"
+      fill_in :participatory_process_step_description_ca, with: "Descripció més llarga"
+      fill_in :participatory_process_step_start_date, with: 1.months.ago
+      fill_in :participatory_process_step_end_date, with: 2.months.from_now
+
+      find("*[type=submit]").click
+    end
+
+    within ".flash" do
+      expect(page).to have_content("successfully")
+    end
+
+    within "table" do
+      expect(page).to have_content("My participatory process step")
+    end
+  end
+
+  it "updates a participatory_process_step" do
+    within "#steps" do
+      within find("tr", text: process_step.title["en"]) do
+        click_link "Edit"
+      end
+    end
+
+    within ".edit_participatory_process_step" do
+      fill_in :participatory_process_step_title_en, with: "My new title"
+      fill_in :participatory_process_step_title_es, with: "Mi nuevo título"
+      fill_in :participatory_process_step_title_ca, with: "El meu nou títol"
+
+      find("*[type=submit]").click
+    end
+
+    within ".flash" do
+      expect(page).to have_content("successfully")
+    end
+
+    within "#steps table" do
+      expect(page).to have_content("My new title")
+      click_link("My new title")
+    end
+  end
+
+  context "deleting a participatory process step" do
+    let!(:process_step2) { create(:participatory_process_step, participatory_process: participatory_process) }
+
+    before do
+      visit decidim_admin.participatory_process_path(participatory_process)
+    end
+
+    it "deletes a participatory_process_step" do
+      within find("tr", text: process_step2.title["en"]) do
+        click_link "Destroy"
+      end
+
+      within ".flash" do
+        expect(page).to have_content("successfully")
+      end
+
+      within "table" do
+        expect(page).to_not have_content(process_step2.title)
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_form_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe ParticipatoryProcessForm do
+      let(:title) do
+        {
+          en: "Title",
+          es: "Título",
+          ca: "Títol"
+        }
+      end
+      let(:subtitle) do
+        {
+          en: "Subtitle",
+          es: "Subtítulo",
+          ca: "Subtítol"
+        }
+      end
+      let(:description) do
+        {
+          en: "Description",
+          es: "Descripción",
+          ca: "Descripció"
+        }
+      end
+      let(:short_description) do
+        {
+          en: "Short description",
+          es: "Descripción corta",
+          ca: "Descripció curta"
+        }
+      end
+      let(:slug) { "slug" }
+      let(:attributes) do
+        {
+          "participatory_process" => {
+            "title_en" => title[:en],
+            "title_es" => title[:es],
+            "title_ca" => title[:ca],
+            "subtitle_en" => subtitle[:en],
+            "subtitle_es" => subtitle[:es],
+            "subtitle_ca" => subtitle[:ca],
+            "description_en" => description[:en],
+            "description_es" => description[:es],
+            "description_ca" => description[:ca],
+            "short_description_en" => short_description[:en],
+            "short_description_es" => short_description[:es],
+            "short_description_ca" => short_description[:ca],
+            "slug" => slug
+          }
+        }
+      end
+
+      subject { described_class.from_params(attributes) }
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when some language in title is missing" do
+        let(:title) do
+          {
+            en: "Title",
+            ca: "Títol"
+          }
+        end
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when some language in subtitle is missing" do
+        let(:subtitle) do
+          {
+            en: "Subtitle",
+            ca: "Subtítol"
+          }
+        end
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when some language in description is missing" do
+        let(:description) do
+          {
+            ca: "Descripció"
+          }
+        end
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when some language in short_description is missing" do
+        let(:short_description) do
+          {
+            en: "Short description"
+          }
+        end
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when slug is missing" do
+        let(:slug) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when slug is not unique" do
+        before do
+          create(:participatory_process, slug: slug)
+        end
+
+        it "is not valid" do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:slug]).to_not be_empty
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/forms/participatory_process_step_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_step_form_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe ParticipatoryProcessStepForm do
+      let(:title) do
+        {
+          en: "Title",
+          es: "Título",
+          ca: "Títol"
+        }
+      end
+      let(:description) do
+        {
+          en: "Description",
+          es: "Descripción",
+          ca: "Descripció"
+        }
+      end
+      let(:short_description) do
+        {
+          en: "Short description",
+          es: "Descripción corta",
+          ca: "Descripció curta"
+        }
+      end
+      let(:start_date) { 1.month.ago }
+      let(:end_date) { 2.months.from_now }
+      let(:attributes) do
+        {
+          "participatory_process_step" => {
+            "title_en" => title[:en],
+            "title_es" => title[:es],
+            "title_ca" => title[:ca],
+            "description_en" => description[:en],
+            "description_es" => description[:es],
+            "description_ca" => description[:ca],
+            "short_description_en" => short_description[:en],
+            "short_description_es" => short_description[:es],
+            "short_description_ca" => short_description[:ca],
+            "start_date" => start_date,
+            "end_date" => end_date,
+          }
+        }
+      end
+
+      subject { described_class.from_params(attributes) }
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when some language in title is missing" do
+        let(:title) do
+          {
+            en: "Title",
+            ca: "Títol"
+          }
+        end
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when some language in description is missing" do
+        let(:description) do
+          {
+            ca: "Descripció"
+          }
+        end
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when some language in short_description is missing" do
+        let(:short_description) do
+          {
+            en: "Short description"
+          }
+        end
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when the start_date is later than end_date" do
+        let(:start_date) { 1.month.from_now }
+        let(:end_date) { 2.months.ago }
+
+        it { is_expected.to be_invalid }
+
+        it "has an error" do
+          subject.valid?
+
+          expect(subject.errors).to_not be_empty
+          expect(subject.errors[:end_date]).to_not be_empty
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/forms/participatory_process_step_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_step_form_spec.rb
@@ -25,8 +25,8 @@ module Decidim
           ca: "Descripció curta"
         }
       end
-      let(:start_date) { 1.month.ago }
-      let(:end_date) { 2.months.from_now }
+      let(:start_date) {}
+      let(:end_date) {}
       let(:attributes) do
         {
           "participatory_process_step" => {
@@ -93,7 +93,20 @@ module Decidim
 
           expect(subject.errors).to_not be_empty
           expect(subject.errors[:end_date]).to_not be_empty
+          expect(subject.errors[:start_date]).to_not be_empty
         end
+      end
+
+      context "when start_date is present" do
+        let(:start_date) { 1.month.from_now }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when end_date is present" do
+        let(:end_date) { 2.months.ago }
+
+        it { is_expected.to be_valid }
       end
     end
   end

--- a/decidim-admin/spec/policies/participatory_process_policy_spec.rb
+++ b/decidim-admin/spec/policies/participatory_process_policy_spec.rb
@@ -42,6 +42,13 @@ module Decidim
 
         subject { described_class.new(user, processes) }
 
+        context "with an empty collection" do
+          let(:user) { create(:user, :admin, organization: organization) }
+          let(:processes) { [] }
+
+          it { is_expected.to permit_action(:index) }
+        end
+
         context "being a regular user" do
           let(:user) { create(:user) }
 

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -7,6 +7,7 @@ module Decidim
   # active.
   class ParticipatoryProcess < ApplicationRecord
     belongs_to :organization, foreign_key: "decidim_organization_id", class_name: Decidim::Organization
+    has_many :steps, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcessStep
 
     validates :slug, presence: true
     validates :slug, uniqueness: true

--- a/decidim-core/app/models/decidim/participatory_process_step.rb
+++ b/decidim-core/app/models/decidim/participatory_process_step.rb
@@ -5,5 +5,6 @@ module Decidim
   # active.
   class ParticipatoryProcessStep < ApplicationRecord
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcess
+    delegate :organization, to: :participatory_process
   end
 end

--- a/decidim-core/app/models/decidim/participatory_process_step.rb
+++ b/decidim-core/app/models/decidim/participatory_process_step.rb
@@ -7,7 +7,7 @@ module Decidim
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcess
     has_one :organization, through: :participatory_process
 
-    validates :end_date,
-              date: { after: :start_date }
+    validates :start_date, date: { before: :end_date, allow_blank: true, if: proc { |obj| obj.end_date.present? } }
+    validates :end_date, date: { after: :start_date, allow_blank: true, if: proc { |obj| obj.start_date.present? } }
   end
 end

--- a/decidim-core/app/models/decidim/participatory_process_step.rb
+++ b/decidim-core/app/models/decidim/participatory_process_step.rb
@@ -5,6 +5,6 @@ module Decidim
   # active.
   class ParticipatoryProcessStep < ApplicationRecord
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcess
-    delegate :organization, to: :participatory_process
+    has_one :organization, through: :participatory_process
   end
 end

--- a/decidim-core/app/models/decidim/participatory_process_step.rb
+++ b/decidim-core/app/models/decidim/participatory_process_step.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Decidim
+  # A ParticipatoryProcess is composed of many steps that hold different
+  # features that will show up in the depending on what step is currently
+  # active.
+  class ParticipatoryProcessStep < ApplicationRecord
+    belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcess
+  end
+end

--- a/decidim-core/app/models/decidim/participatory_process_step.rb
+++ b/decidim-core/app/models/decidim/participatory_process_step.rb
@@ -6,5 +6,8 @@ module Decidim
   class ParticipatoryProcessStep < ApplicationRecord
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcess
     has_one :organization, through: :participatory_process
+
+    validates :end_date,
+              date: { after: :start_date }
   end
 end

--- a/decidim-core/db/migrate/20161017085822_add_participatory_process_steps.rb
+++ b/decidim-core/db/migrate/20161017085822_add_participatory_process_steps.rb
@@ -1,0 +1,18 @@
+class AddParticipatoryProcessSteps < ActiveRecord::Migration[5.0]
+  def change
+    create_table :decidim_participatory_process_steps do |t|
+      t.hstore :title, null: false
+      t.hstore :short_description, null: false
+      t.hstore :description, null: false
+      t.datetime :start_date
+      t.datetime :end_date
+      t.references :decidim_participatory_process,
+        foreign_key: true,
+        index: { name: 'index_decidim_processes_steps__on_decidim_process_id' }
+
+      t.timestamps
+    end
+
+    add_column :decidim_participatory_processes, :active_step_id, :boolean
+  end
+end

--- a/decidim-core/db/migrate/20161017085822_add_participatory_process_steps.rb
+++ b/decidim-core/db/migrate/20161017085822_add_participatory_process_steps.rb
@@ -12,7 +12,5 @@ class AddParticipatoryProcessSteps < ActiveRecord::Migration[5.0]
 
       t.timestamps
     end
-
-    add_column :decidim_participatory_processes, :active_step_id, :boolean
   end
 end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -29,31 +29,81 @@ if !Rails.env.production? || ENV["SEED"]
     tos_agreement: true
   )
 
-  Decidim::ParticipatoryProcess.create!(
+  participatory_process1 = Decidim::ParticipatoryProcess.create!(
     title: {
-      en: 'Urbanistic plan for Newtown neighbourhood',
-      es: 'Plan urbanístico para el barrio de Villanueva',
-      ca: 'Pla urbanístic pel barri de Vilanova'
+      en: "Urbanistic plan for Newtown neighbourhood",
+      es: "Plan urbanístico para el barrio de Villanueva",
+      ca: "Pla urbanístic pel barri de Vilanova"
     },
-    slug: 'urbanistic-plan-for-newtown-neighbourhood',
+    slug: "urbanistic-plan-for-newtown-neighbourhood",
     subtitle: {
-      en: 'Go for it!',
-      es: 'Vamos!',
-      ca: 'Som-hi!'
+      en: "Go for it!",
+      es: "Vamos!",
+      ca: "Som-hi!"
     },
-    hashtag: '#urbaNewtown',
+    hashtag: "#urbaNewtown",
     short_description: {
-      en: '<p>Short description</p>',
-      es: '<p>Descripción corta</p>',
-      ca: '<p>Descripció curta</p>'
+      en: "<p>Short description</p>",
+      es: "<p>Descripción corta</p>",
+      ca: "<p>Descripció curta</p>"
     },
     description: {
-      en: '<p>Description</p>',
-      es: '<p>Descripción</p>',
-      ca: '<p>Descripció</p>'
+      en: "<p>Description</p>",
+      es: "<p>Descripción</p>",
+      ca: "<p>Descripció</p>"
     },
     hero_image: File.new(File.join(File.dirname(__FILE__), "seeds", "city.jpeg")),
     banner_image: File.new(File.join(File.dirname(__FILE__), "seeds", "city2.jpeg")),
+    promoted: true,
     organization: staging_organization
+  )
+
+  Decidim::ParticipatoryProcess.create!(
+    title: {
+      en: "Open a new library in the center",
+      es: "Abrir una nueva biblioteca en el centro",
+      ca: "Obrir una nova biblioteca al centre"
+    },
+    slug: "open-a-new-library-in-the-center",
+    subtitle: {
+      en: "Easier access to culture for everybody",
+      es: "Un acceso más fácil a la cultura para todos",
+      ca: "Un accés més fàcil a la cultura per a tothom"
+    },
+    hashtag: "#libraryDowntown",
+    short_description: {
+      en: "<p>Short description</p>",
+      es: "<p>Descripción corta</p>",
+      ca: "<p>Descripció curta</p>"
+    },
+    description: {
+      en: "<p>Description</p>",
+      es: "<p>Descripción</p>",
+      ca: "<p>Descripció</p>"
+    },
+    hero_image: File.new(File.join(File.dirname(__FILE__), "seeds", "city2.jpeg")),
+    banner_image: File.new(File.join(File.dirname(__FILE__), "seeds", "city3.jpeg")),
+    organization: staging_organization
+  )
+
+  Decidim::ParticipatoryProcessStep.create!(
+    title: {
+      en: "Information",
+      es: "Información",
+      ca: "Informació"
+    },
+    short_description: {
+      en: "<p>Short description</p>",
+      es: "<p>Descripción corta</p>",
+      ca: "<p>Descripció curta</p>"
+    },
+    description: {
+      en: "<p>Description</p>",
+      es: "<p>Descripción</p>",
+      ca: "<p>Descripció</p>"
+    },
+    start_date: 1.month.ago.at_midnight,
+    end_date: 2.months.from_now.at_midnight,
+    participatory_process: participatory_process1
   )
 end

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency "redis", "~> 3.3.0"
   s.add_dependency "roadie-rails", "~> 1.0"
   s.add_dependency "high_voltage", "~> 3.0.0"
+  s.add_dependency "date_validator", "~> 0.9.0"
 
   s.add_development_dependency "decidim-dev", Decidim.version
 end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -20,6 +20,7 @@ require "roadie-rails"
 require "carrierwave"
 require "high_voltage"
 require "rails-i18n"
+require "date_validator"
 
 module Decidim
   module Core

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -20,6 +20,15 @@ FactoryGirl.define do
     end
   end
 
+  factory :participatory_process_step, class: Decidim::ParticipatoryProcessStep do
+    sequence(:title) { |n| { en: "Participatory Process Step ##{n}", ca: "Fase de procés participatiu ##{n}", es: "Fase de proceso participativo ##{n}" } }
+    short_description en: "<p>Short description</p>", ca: "<p>Descripció curta</p>", es: "<p>Descripción corta</p>"
+    description       en: "<p>Description</p>", ca: "<p>Descripció</p>", es: "<p>Descripción</p>"
+    start_date 1.month.ago.at_midnight
+    end_date 2.month.from_now.at_midnight
+    participatory_process
+  end
+
   factory :user, class: Decidim::User do
     sequence(:email)      { |n| "user#{n}@citizen.corp" }
     password              "password1234"

--- a/decidim-core/spec/models/decidim/participatory_process_step_spec.rb
+++ b/decidim-core/spec/models/decidim/participatory_process_step_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe ParticipatoryProcessStep do
+    let(:participatory_process_step) { build(:participatory_process_step) }
+
+    subject { participatory_process_step }
+
+    it { is_expected.to be_valid }
+
+    context "when start date is after end date" do
+      let(:participatory_process_step) do
+        build(:participatory_process_step, start_date: 2.months.from_now, end_date: 1.month.ago)
+      end
+
+      it { is_expected.to_not be_valid }
+
+      it "has an error in end_date" do
+        subject.valid?
+
+        expect(subject.errors[:end_date]).to_not be_empty
+      end
+    end
+  end
+end

--- a/decidim-core/spec/models/decidim/participatory_process_step_spec.rb
+++ b/decidim-core/spec/models/decidim/participatory_process_step_spec.rb
@@ -22,5 +22,17 @@ module Decidim
         expect(subject.errors[:end_date]).to_not be_empty
       end
     end
+
+    context "when start_date is present" do
+      let(:start_date) { 1.month.from_now }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when end_date is present" do
+      let(:end_date) { 2.months.ago }
+
+      it { is_expected.to be_valid }
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Some of the participatory processes need to have different steps. They will enable/disable different features in the future. Implements part of #55.

#### :dart: Acceptance criteria?
A ParticipatoryProcess can have a list of steps (unordered by now). All CRUD actions can be applied to them.

#### :pushpin: Related tasks?
See #55.

#### :clipboard: Subtasks
- [x] Add migration
- [x] Add layouts
- [x] Add locales
- [x] Add feature spec
- [x] Add unit tests for related classes
- [x] Remove the `active_step_id` field from the migration, we'll do it in another PR.


#### :ghost: GIF
![](https://media.giphy.com/media/SmGLzevndqQX6/giphy.gif)