### PR TITLE
Add active steps

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/activate_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/activate_participatory_process_step.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 module Decidim
   module Admin
-    # A command with all the business logic when activating a participatory
-    # process step.
+    # A command that sets a step in a participatory process as active (and
+    # unsets a previous active step)
     class ActivateParticipatoryProcessStep < Rectify::Command
       # Public: Initializes the command.
       #
@@ -32,9 +32,7 @@ module Decidim
       attr_reader :step
 
       def deactivate_active_steps
-        Decidim::ParticipatoryProcessStep
-          .where(decidim_participatory_process_id: step.decidim_participatory_process_id, active: true)
-          .update_all(active: false)
+        step.participatory_process.steps.where(active: true).update_all(active: false)
       end
 
       def activate_step

--- a/decidim-admin/app/commands/decidim/admin/activate_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/activate_participatory_process_step.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A command with all the business logic when creating a new participatory
+    # process in the system.
+    class ActivateParticipatoryProcessStep < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # step - A ParticipatoryProcessStep that will be activated
+      def initialize(step)
+        @step = step
+      end
+
+      # Executes the command. Braodcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the data wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if step.nil? || step.active?
+
+        Decidim::ParticipatoryProcessStep.transaction do
+          deactivate_active_steps
+          activate_step
+        end
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :step
+
+      def deactivate_active_steps
+        Decidim::ParticipatoryProcessStep
+          .where(decidim_participatory_process_id: step.decidim_participatory_process_id, active: true)
+          .update_all(active: false)
+      end
+
+      def activate_step
+        step.update_attribute(:active, true)
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/deactivate_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/deactivate_participatory_process_step.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 module Decidim
   module Admin
-    # A command with all the business logic when deactivating a participatory
-    # process step.
+    # A command that sets all steps in a participatory process as inactive
     class DeactivateParticipatoryProcessStep < Rectify::Command
       # Public: Initializes the command.
       #
@@ -29,9 +28,7 @@ module Decidim
       attr_reader :step
 
       def deactivate_active_steps
-        Decidim::ParticipatoryProcessStep
-          .where(participatory_process: step.participatory_process, active: true)
-          .update_all(active: false)
+        step.participatory_process.steps.where(active: true).update_all(active: false)
       end
     end
   end

--- a/decidim-admin/app/commands/decidim/admin/deactivate_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/deactivate_participatory_process_step.rb
@@ -1,29 +1,26 @@
 # frozen_string_literal: true
 module Decidim
   module Admin
-    # A command with all the business logic when activating a participatory
+    # A command with all the business logic when deactivating a participatory
     # process step.
-    class ActivateParticipatoryProcessStep < Rectify::Command
+    class DeactivateParticipatoryProcessStep < Rectify::Command
       # Public: Initializes the command.
       #
-      # step - A ParticipatoryProcessStep that will be activated
+      # step - A ParticipatoryProcessStep that will be deactivated
       def initialize(step)
         @step = step
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the data wasn't valid and we couldn't proceed.
       #
       # Returns nothing.
       def call
-        return broadcast(:invalid) if step.nil? || step.active?
+        return broadcast(:invalid) if step.nil? || !step.active?
 
-        Decidim::ParticipatoryProcessStep.transaction do
-          deactivate_active_steps
-          activate_step
-        end
+        deactivate_active_steps
         broadcast(:ok)
       end
 
@@ -35,10 +32,6 @@ module Decidim
         Decidim::ParticipatoryProcessStep
           .where(decidim_participatory_process_id: step.decidim_participatory_process_id, active: true)
           .update_all(active: false)
-      end
-
-      def activate_step
-        step.update_attribute(:active, true)
       end
     end
   end

--- a/decidim-admin/app/commands/decidim/admin/deactivate_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/deactivate_participatory_process_step.rb
@@ -30,7 +30,7 @@ module Decidim
 
       def deactivate_active_steps
         Decidim::ParticipatoryProcessStep
-          .where(decidim_participatory_process_id: step.decidim_participatory_process_id, active: true)
+          .where(participatory_process: step.participatory_process, active: true)
           .update_all(active: false)
       end
     end

--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_step_activations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_step_activations_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require_dependency "decidim/admin/application_controller"
+
+module Decidim
+  module Admin
+    # Controller that allows managing all the Admins.
+    #
+    class ParticipatoryProcessStepActivationsController < ApplicationController
+      def create
+        authorize ParticipatoryProcessStep
+
+        ActivateParticipatoryProcessStep.call(collection.find(params[:step_id])) do
+          on(:ok) do
+            flash[:notice] = I18n.t("participatory_process_step_activations.create.success", scope: "decidim.admin")
+            redirect_to participatory_process_path(participatory_process)
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("participatory_process_step_activations.create.error", scope: "decidim.admin")
+            redirect_to participatory_process_path(participatory_process)
+          end
+        end
+      end
+
+      private
+
+      def participatory_process
+        current_organization.participatory_processes.find(params[:participatory_process_id])
+      end
+
+      def collection
+        participatory_process.steps
+      end
+
+      def policy_class(_record)
+        Decidim::Admin::ParticipatoryProcessPolicy
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_step_activations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_step_activations_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       def create
         authorize ParticipatoryProcessStep
 
-        ActivateParticipatoryProcessStep.call(collection.find(params[:step_id])) do
+        ActivateParticipatoryProcessStep.call(process_step) do
           on(:ok) do
             flash[:notice] = I18n.t("participatory_process_step_activations.create.success", scope: "decidim.admin")
             redirect_to participatory_process_path(participatory_process)
@@ -22,7 +22,27 @@ module Decidim
         end
       end
 
+      def destroy
+        authorize process_step
+
+        DeactivateParticipatoryProcessStep.call(process_step) do
+          on(:ok) do
+            flash[:notice] = I18n.t("participatory_process_step_activations.destroy.success", scope: "decidim.admin")
+            redirect_to participatory_process_path(participatory_process)
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("participatory_process_step_activations.destroy.error", scope: "decidim.admin")
+            redirect_to participatory_process_path(participatory_process)
+          end
+        end
+      end
+
       private
+
+      def process_step
+        collection.find(params[:step_id])
+      end
 
       def participatory_process
         current_organization.participatory_processes.find(params[:participatory_process_id])

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/show.html.erb
@@ -39,6 +39,7 @@
           <th><%= t("models.participatory_process_step.fields.title", scope: "decidim.admin") %></th>
           <th><%= t("models.participatory_process_step.fields.start_date", scope: "decidim.admin") %></th>
           <th><%= t("models.participatory_process_step.fields.end_date", scope: "decidim.admin") %></th>
+          <th><%= t("models.participatory_process_step.fields.active", scope: "decidim.admin") %></th>
           <th class="actions"><%= t("actions.title", scope: "decidim.admin") %></th>
         </tr>
       </thead>
@@ -54,8 +55,14 @@
             <td>
               <%= l step.end_date, format: :short %>
             </td>
+            <td>
+              <%= humanize_boolean step.active? %>
+              <% unless step.active? %>
+              <% end %>
+            </td>
             <td class="actions">
               <%= link_to_if policy(step).edit?, t("actions.edit", scope: "decidim.admin"), edit_participatory_process_step_path(@participatory_process, step) %>
+              <%= link_to "Set as active", participatory_process_step_activate_path(@participatory_process, step), method: :post, class: "small button secondary" unless step.active? %>
               <%= link_to_if policy(step).destroy?, t("actions.destroy", scope: "decidim.admin"), participatory_process_step_path(@participatory_process, step), method: :delete, class: "small alert button", data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
             </td>
           </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/show.html.erb
@@ -57,8 +57,6 @@
             </td>
             <td>
               <%= humanize_boolean step.active? %>
-              <% unless step.active? %>
-              <% end %>
             </td>
             <td class="actions">
               <%= link_to_if policy(step).edit?, t("actions.edit", scope: "decidim.admin"), edit_participatory_process_step_path(@participatory_process, step) %>

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/show.html.erb
@@ -62,7 +62,11 @@
             </td>
             <td class="actions">
               <%= link_to_if policy(step).edit?, t("actions.edit", scope: "decidim.admin"), edit_participatory_process_step_path(@participatory_process, step) %>
-              <%= link_to "Set as active", participatory_process_step_activate_path(@participatory_process, step), method: :post, class: "small button secondary" unless step.active? %>
+              <% if step.active? %>
+                <%= link_to t("actions.deactivate", scope: "decidim.admin"), participatory_process_step_activate_path(@participatory_process, step), method: :delete, class: "small button secondary" %>
+              <% else %>
+                <%= link_to t("actions.activate", scope: "decidim.admin"), participatory_process_step_activate_path(@participatory_process, step), method: :post, class: "small button secondary" %>
+              <% end %>
               <%= link_to_if policy(step).destroy?, t("actions.destroy", scope: "decidim.admin"), participatory_process_step_path(@participatory_process, step), method: :delete, class: "small alert button", data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
             </td>
           </tr>

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -7,7 +7,9 @@ ca:
   decidim:
     admin:
       actions:
+        activate: Activar
         confirm_destroy: Segur que ho vols eliminar?
+        deactivate: Desactivar
         destroy: Eliminar
         edit: Editar
         new: Nou %{name}
@@ -32,10 +34,18 @@ ca:
             slug_uniqueness: Ja existeix un altre procés participatiu amb el mateix identificador
         participatory_process_step:
           fields:
+            active: Active
             end_date: Data de finalització
             start_date: Data d'inici
             title: Títol
           name: Name
+      participatory_process_step_activations:
+        create:
+          error: S'ha produït un error en activar aquesta fase de procés participatiu.
+          success: La fase de procés participatiu s'ha activat correctament.
+        destroy:
+          error: S'ha produït un error en desactivar aquesta fase de procés participatiu.
+          success: La fase de procés participatiu s'ha desactivat correctament.
       participatory_process_steps:
         create:
           error: S'ha produït un error en crear una nova fase de procés participatiu.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -7,7 +7,7 @@ en:
   decidim:
     admin:
       actions:
-        activate: Set as active
+        activate: Activate
         confirm_destroy: Are you sure you want to delete this?
         deactivate: Deactivate
         destroy: Destroy

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -7,7 +7,9 @@ en:
   decidim:
     admin:
       actions:
+        activate: Set as active
         confirm_destroy: Are you sure you want to delete this?
+        deactivate: Deactivate
         destroy: Destroy
         edit: Edit
         new: New %{name}
@@ -32,10 +34,18 @@ en:
             slug_uniqueness: Another participatory process with the same slug already exists
         participatory_process_step:
           fields:
+            active: Active
             end_date: End date
             start_date: Start date
             title: Title
           name: Participatory process step
+      participatory_process_step_activations:
+        create:
+          error: There was an error activating this participatory process step.
+          success: Participatory process step activated successfully
+        destroy:
+          error: There was an error deactivating this participatory process step.
+          success: Participatory process step deactivated successfully
       participatory_process_steps:
         create:
           error: There was an error creating a new participatory process step.

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -7,7 +7,9 @@ es:
   decidim:
     admin:
       actions:
+        activate: Activar
         confirm_destroy: "¿Seguro que lo quieres eliminar?"
+        deactivate: Desactivar
         destroy: Eliminar
         edit: Editar
         new: Nuevo %{name}
@@ -32,10 +34,18 @@ es:
             slug_uniqueness: Ya existe otro proceso participativo con el mismo identificador
         participatory_process_step:
           fields:
+            active: Activo
             end_date: Fecha de finalización
             start_date: Fecha de inicio
             title: Título
           name: Fase de proceso participativo
+      participatory_process_step_activations:
+        create:
+          error: Se ha producido un error al activar esta fase de proceso participativo.
+          success: La fase de proceso participativo se ha activado correctamente.
+        destroy:
+          error: Se ha producido un error al desactivar esta fase de proceso participativo.
+          success: La fase de proceso participativo se ha desactivado correctamente.
       participatory_process_steps:
         create:
           error: Se ha producido un error al crear una nueva fase de proceso participativo.

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -2,7 +2,9 @@
 Decidim::Admin::Engine.routes.draw do
   constraints(->(request) { Decidim::Admin::OrganizationDashboardConstraint.new(request).matches? }) do
     resources :participatory_processes do
-      resources :steps, controller: "participatory_process_steps", except: :index
+      resources :steps, controller: "participatory_process_steps", except: :index do
+        resource :activate, controller: "participatory_process_step_activations", only: :create
+      end
     end
     root to: "dashboard#show"
   end

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -3,7 +3,7 @@ Decidim::Admin::Engine.routes.draw do
   constraints(->(request) { Decidim::Admin::OrganizationDashboardConstraint.new(request).matches? }) do
     resources :participatory_processes do
       resources :steps, controller: "participatory_process_steps", except: :index do
-        resource :activate, controller: "participatory_process_step_activations", only: :create
+        resource :activate, controller: "participatory_process_step_activations", only: [:create, :destroy]
       end
     end
     root to: "dashboard#show"

--- a/decidim-admin/spec/commands/activate_participatory_process_step_spec.rb
+++ b/decidim-admin/spec/commands/activate_participatory_process_step_spec.rb
@@ -3,32 +3,13 @@ require "spec_helper"
 describe Decidim::Admin::DeactivateParticipatoryProcessStep do
   let(:process_step) { create :participatory_process_step, :active }
 
-  before do
-    @success = nil
-    @failure = nil
-  end
-
-  def success
-    @success = true
-  end
-
-  def failure
-    @failure = true
-  end
-
-  subject do
-    described_class.call(process_step) do
-      on(:ok) { success }
-      on(:invalid) { failure }
-    end
-  end
+  subject { described_class.new(process_step) }
 
   context "when the step is nil" do
     let(:process_step) { nil }
 
     it "is not valid" do
-      subject
-      expect(@failure).to eq true
+      expect { subject.call }.to broadcast(:invalid)
     end
   end
 
@@ -36,19 +17,17 @@ describe Decidim::Admin::DeactivateParticipatoryProcessStep do
     let(:process_step) { create :participatory_process_step }
 
     it "is not valid" do
-      subject
-      expect(@failure).to eq true
+      expect { subject.call }.to broadcast(:invalid)
     end
   end
 
   context "when the step is active" do
     it "is valid" do
-      subject
-      expect(@success).to eq true
+      expect { subject.call }.to broadcast(:ok)
     end
 
     it "deactivates it" do
-      subject
+      subject.call
       process_step.reload
       expect(process_step).not_to be_active
     end

--- a/decidim-admin/spec/commands/activate_participatory_process_step_spec.rb
+++ b/decidim-admin/spec/commands/activate_participatory_process_step_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+describe Decidim::Admin::DeactivateParticipatoryProcessStep do
+  let(:process_step) { create :participatory_process_step, :active }
+
+  before do
+    @success = nil
+    @failure = nil
+  end
+
+  def success
+    @success = true
+  end
+
+  def failure
+    @failure = true
+  end
+
+  subject do
+    described_class.call(process_step) do
+      on(:ok) { success }
+      on(:invalid) { failure }
+    end
+  end
+
+  context "when the step is nil" do
+    let(:process_step) { nil }
+
+    it "is not valid" do
+      subject
+      expect(@failure).to eq true
+    end
+  end
+
+  context "when the step is inactive" do
+    let(:process_step) { create :participatory_process_step }
+
+    it "is not valid" do
+      subject
+      expect(@failure).to eq true
+    end
+  end
+
+  context "when the step is active" do
+    it "is valid" do
+      subject
+      expect(@success).to eq true
+    end
+
+    it "deactivates it" do
+      subject
+      process_step.reload
+      expect(process_step).not_to be_active
+    end
+  end
+end

--- a/decidim-admin/spec/commands/deactivate_participatory_process_step_spec.rb
+++ b/decidim-admin/spec/commands/deactivate_participatory_process_step_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+describe Decidim::Admin::ActivateParticipatoryProcessStep do
+  let(:process_step) { create :participatory_process_step }
+
+  before do
+    @success = nil
+    @failure = nil
+  end
+
+  def success
+    @success = true
+  end
+
+  def failure
+    @failure = true
+  end
+
+  subject do
+    described_class.call(process_step) do
+      on(:ok) { success }
+      on(:invalid) { failure }
+    end
+  end
+
+  context "when the step is nil" do
+    let(:process_step) { nil }
+
+    it "is not valid" do
+      subject
+      expect(@failure).to eq true
+    end
+  end
+
+  context "when the step is active" do
+    let(:process_step) { create :participatory_process_step, :active }
+
+    it "is not valid" do
+      subject
+      expect(@failure).to eq true
+    end
+  end
+
+  context "when the step is not active" do
+    let!(:active_step) do
+      create :participatory_process_step, :active, participatory_process: process_step.participatory_process
+    end
+
+    it "is valid" do
+      subject
+      expect(@success).to eq true
+    end
+
+    it "activates it" do
+      subject
+      expect(process_step).to be_active
+    end
+
+    it "deactivates the process active steps" do
+      subject
+      active_step.reload
+      expect(active_step).not_to be_active
+    end
+  end
+end

--- a/decidim-admin/spec/commands/deactivate_participatory_process_step_spec.rb
+++ b/decidim-admin/spec/commands/deactivate_participatory_process_step_spec.rb
@@ -3,32 +3,13 @@ require "spec_helper"
 describe Decidim::Admin::ActivateParticipatoryProcessStep do
   let(:process_step) { create :participatory_process_step }
 
-  before do
-    @success = nil
-    @failure = nil
-  end
-
-  def success
-    @success = true
-  end
-
-  def failure
-    @failure = true
-  end
-
-  subject do
-    described_class.call(process_step) do
-      on(:ok) { success }
-      on(:invalid) { failure }
-    end
-  end
+  subject { described_class.new(process_step) }
 
   context "when the step is nil" do
     let(:process_step) { nil }
 
     it "is not valid" do
-      subject
-      expect(@failure).to eq true
+      expect { subject.call }.to broadcast(:invalid)
     end
   end
 
@@ -36,8 +17,7 @@ describe Decidim::Admin::ActivateParticipatoryProcessStep do
     let(:process_step) { create :participatory_process_step, :active }
 
     it "is not valid" do
-      subject
-      expect(@failure).to eq true
+      expect { subject.call }.to broadcast(:invalid)
     end
   end
 
@@ -47,17 +27,16 @@ describe Decidim::Admin::ActivateParticipatoryProcessStep do
     end
 
     it "is valid" do
-      subject
-      expect(@success).to eq true
+      expect { subject.call }.to broadcast(:ok)
     end
 
     it "activates it" do
-      subject
+      subject.call
       expect(process_step).to be_active
     end
 
     it "deactivates the process active steps" do
-      subject
+      subject.call
       active_step.reload
       expect(active_step).not_to be_active
     end

--- a/decidim-admin/spec/features/manage_participatory_process_steps_spec.rb
+++ b/decidim-admin/spec/features/manage_participatory_process_steps_spec.rb
@@ -13,10 +13,12 @@ describe "Manage participatory process steps", type: :feature do
       short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" }
     )
   end
+  let(:active) { false }
   let!(:process_step) do
     create(
       :participatory_process_step,
       participatory_process: participatory_process,
+      active: active,
       description: { en: "Description", ca: "Descripció", es: "Descripción" },
       short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" }
     )
@@ -117,6 +119,32 @@ describe "Manage participatory process steps", type: :feature do
 
       within "table" do
         expect(page).to_not have_content(process_step2.title)
+      end
+    end
+  end
+
+  context "activating a step" do
+    it "activates a step" do
+      within find("tr", text: process_step.title["en"]) do
+        click_link "Set as active"
+      end
+
+      within find("tr", text: process_step.title["en"]) do
+        expect(page).to have_content("Deactivate")
+      end
+    end
+  end
+
+  context "deactivating a step" do
+    let(:active) { true }
+
+    it "deactivates a step" do
+      within find("tr", text: process_step.title["en"]) do
+        click_link "Deactivate"
+      end
+
+      within find("tr", text: process_step.title["en"]) do
+        expect(page).to have_content("Set as active")
       end
     end
   end

--- a/decidim-admin/spec/features/manage_participatory_process_steps_spec.rb
+++ b/decidim-admin/spec/features/manage_participatory_process_steps_spec.rb
@@ -126,7 +126,7 @@ describe "Manage participatory process steps", type: :feature do
   context "activating a step" do
     it "activates a step" do
       within find("tr", text: process_step.title["en"]) do
-        click_link "Set as active"
+        click_link "Activate"
       end
 
       within find("tr", text: process_step.title["en"]) do
@@ -144,7 +144,7 @@ describe "Manage participatory process steps", type: :feature do
       end
 
       within find("tr", text: process_step.title["en"]) do
-        expect(page).to have_content("Set as active")
+        expect(page).to have_content("Activate")
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
@@ -14,7 +14,7 @@ module Decidim
     end
 
     def participatory_processes
-      @participatory_processes ||= current_organization.participatory_processes
+      @participatory_processes ||= current_organization.participatory_processes.includes(:active_step)
     end
 
     def promoted_processes

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -9,6 +9,9 @@ module Decidim
     belongs_to :organization, foreign_key: "decidim_organization_id", class_name: Decidim::Organization
     has_many :steps, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcessStep
     has_one :active_step, -> { where(active: true) }, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcessStep
+
+    attr_readonly :active_step
+
     validates :slug, presence: true
     validates :slug, uniqueness: true
 

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -8,7 +8,7 @@ module Decidim
   class ParticipatoryProcess < ApplicationRecord
     belongs_to :organization, foreign_key: "decidim_organization_id", class_name: Decidim::Organization
     has_many :steps, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcessStep
-
+    has_one :active_step, -> { where(active: true) }, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcessStep
     validates :slug, presence: true
     validates :slug, uniqueness: true
 

--- a/decidim-core/app/models/decidim/participatory_process_step.rb
+++ b/decidim-core/app/models/decidim/participatory_process_step.rb
@@ -9,5 +9,7 @@ module Decidim
 
     validates :start_date, date: { before: :end_date, allow_blank: true, if: proc { |obj| obj.end_date.present? } }
     validates :end_date, date: { after: :start_date, allow_blank: true, if: proc { |obj| obj.start_date.present? } }
+
+    validates :active, uniqueness: { scope: :decidim_participatory_process_id }, if: proc { |step| step.active? }
   end
 end

--- a/decidim-core/app/views/decidim/participatory_processes/_participatory_process.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_participatory_process.html.erb
@@ -10,10 +10,16 @@
     </div>
     <div class="card__footer">
       <div class="card__support">
+        <% if participatory_process.active_step %>
+          <span class="card--process__small">
+            <%= t(".active_step", scope: "layouts") %>
+            <strong><%= translated_attribute participatory_process.active_step.title %></strong>
+          </span>
+        <% end %>
         <span class="card--process__small"></span>
-        <button class="card__button button small">
+        <%= link_to participatory_process_path(participatory_process), class: "card__button button small" do %>
           <%= t(".take_part", scope: "layouts") %>
-        </button>
+        <% end %>
       </div>
     </div>
   </article>

--- a/decidim-core/app/views/decidim/participatory_processes/_promoted_process.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_promoted_process.html.erb
@@ -18,6 +18,11 @@
           <div class="large-6 large-offset-6 columns">
             <%= link_to participatory_process_path(promoted_process), class: "button expanded button--sc" do %>
               <%= t(".take_part", scope: "layouts") %>
+              <% if promoted_process.active_step %>
+                <span class="button__info">
+                  <%= t(".active_step", scope: "layouts") %> <%= translated_attribute promoted_process.active_step.title %>
+                </span>
+              <% end %>
             <% end %>
           </div>
         </div>

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -72,8 +72,10 @@ ca:
             one: "%{count} procés"
             other: "%{count} processos"
         participatory_process:
+          active_step: "Fase actual:"
           take_part: Participa
         promoted_process:
+          active_step: "Fase actual:"
           more_info: Més informació
           take_part: Participa
   locales:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -68,8 +68,10 @@ en:
             one: "%{count} process"
             other: "%{count} processes"
         participatory_process:
+          active_step: "Current step:"
           take_part: Take part
         promoted_process:
+          active_step: "Current step:"
           more_info: More info
           take_part: Take part
   locales:

--- a/decidim-core/config/locales/es.yml
+++ b/decidim-core/config/locales/es.yml
@@ -72,8 +72,10 @@ es:
             one: "%{count} proceso"
             other: "%{count} procesos"
         participatory_process:
+          active_step: "Fase actual:"
           take_part: Participa
         promoted_process:
+          active_step: "Fase actual:"
           more_info: Más información
           take_part: Participa
   locales:

--- a/decidim-core/db/migrate/20161019072016_add_active_flag_to_step.rb
+++ b/decidim-core/db/migrate/20161019072016_add_active_flag_to_step.rb
@@ -1,5 +1,7 @@
 class AddActiveFlagToStep < ActiveRecord::Migration[5.0]
   def change
     add_column :decidim_participatory_process_steps, :active, :boolean, default: false
+
+    add_index :decidim_participatory_process_steps, [:decidim_participatory_process_id, :active], unique: true, where: "active = 't'", name: "unique_index_to_avoid_duplicate_active_steps"
   end
 end

--- a/decidim-core/db/migrate/20161019072016_add_active_flag_to_step.rb
+++ b/decidim-core/db/migrate/20161019072016_add_active_flag_to_step.rb
@@ -1,0 +1,5 @@
+class AddActiveFlagToStep < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_participatory_process_steps, :active, :boolean, default: false
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -102,8 +102,30 @@ if !Rails.env.production? || ENV["SEED"]
       es: "<p>Descripción</p>",
       ca: "<p>Descripció</p>"
     },
+    active: true,
     start_date: 1.month.ago.at_midnight,
     end_date: 2.months.from_now.at_midnight,
+    participatory_process: participatory_process1
+  )
+
+  Decidim::ParticipatoryProcessStep.create!(
+    title: {
+      en: "Proposals",
+      es: "Propuestas",
+      ca: "Propostes"
+    },
+    short_description: {
+      en: "<p>Short description</p>",
+      es: "<p>Descripción corta</p>",
+      ca: "<p>Descripció curta</p>"
+    },
+    description: {
+      en: "<p>Description</p>",
+      es: "<p>Descripción</p>",
+      ca: "<p>Descripció</p>"
+    },
+    start_date: 2.months.from_now.at_midnight,
+    end_date: 3.months.from_now.at_midnight,
     participatory_process: participatory_process1
   )
 end

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -27,6 +27,10 @@ FactoryGirl.define do
     start_date 1.month.ago.at_midnight
     end_date 2.month.from_now.at_midnight
     participatory_process
+
+    trait :active do
+      active true
+    end
   end
 
   factory :user, class: Decidim::User do

--- a/decidim-core/spec/models/decidim/participatory_process_step_spec.rb
+++ b/decidim-core/spec/models/decidim/participatory_process_step_spec.rb
@@ -34,5 +34,25 @@ module Decidim
 
       it { is_expected.to be_valid }
     end
+
+    context "active" do
+      context "when there's an active step in the same process" do
+        let(:active_step) { create :participatory_process_step, :active }
+        let(:participatory_process_step) do
+          build(:participatory_process_step, :active, participatory_process: active_step.participatory_process)
+        end
+
+        it { is_expected.to_not be_valid }
+      end
+
+      context "with multiple inactive steps" do
+        let(:inactive_step) { create :participatory_process_step }
+        let(:participatory_process_step) do
+          build(:participatory_process_step, participatory_process: inactive_step.participatory_process)
+        end
+
+        it { is_expected.to be_valid }
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Now that we have steps since #119, we need to set them as active. There can only be one step set as active at the same time per process.

#### :dart: Acceptance criteria?
Steps can be activated and the active one is shown in the public pages layout.

#### :clipboard: Subtasks
- [x] Add the flag
- [x] Add a way to activate steps
- [x] Add a way to deactivate steps
- [x] Discuss whether a process with steps can have no active steps or not => yes, a process can have multiple steps but no active one
- [x] Show active step in public layouts
- [x] Add specs for the model
- [x] Add specs for the command classes
- [x] Add feature specs
- [x] Make sure the DB does not accept multiple active steps per process

#### :ghost: GIF
![](http://i.imgur.com/hug9ZE4.gif)
