### PR TITLE
This forces rubocop to run in 2.3 mode. Apparently it detects it from `.ruby-version` but it doesn't seem to be the case.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,7 +75,7 @@ AllCops:
   # If a value is specified for TargetRubyVersion then it is used.
   # Else if .ruby-version exists and it contains an MRI version it is used.
   # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
-  TargetRubyVersion: ~
+  TargetRubyVersion: 2.3
 
 # Indent private/protected/public as deep as method definitions
 Style/AccessModifierIndentation:


### PR DESCRIPTION
#### :tophat: What? Why?

Force rubocop to run in 2.3 mode. Apparently it detects it from `.ruby-version` but it doesn't seem to be the case.

#### :ghost: GIF

![](https://media.giphy.com/media/U8bDgsXcnIEFy/giphy.gif)