### PR TITLE
Support generating the app with a specific GitHub branch. Closes #29

### DIFF
--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -32,7 +32,10 @@ module Decidim
                           desc: "Path to the gem"
 
       class_option :edge, type: :boolean, default: false,
-                          desc: "Use GitHub's edge version"
+                          desc: "Use GitHub's edge version from master branch"
+
+      class_option :branch, type: :string, default: nil,
+                            desc: "Use a specific branch from GitHub's version"
 
       class_option :database, type: :string, aliases: "-d", default: "postgresql",
                               desc: "Configure for selected database (options: #{DATABASES.join("/")})"

--- a/lib/generators/decidim/templates/Gemfile.erb
+++ b/lib/generators/decidim/templates/Gemfile.erb
@@ -5,6 +5,8 @@ ruby '<%= RUBY_VERSION %>'
 gem "decidim", path: "<%= options[:path] %>"
 <% elsif options[:edge] %>
 gem "decidim", github: 'codegram/decidim'
+<% elsif options[:branch] %>
+gem "decidim", github: 'codegram/decidim', branch: "<%= options[:branch] %>"
 <% else %>
 gem "decidim", "<%= Gem::Specification.find_by_name("decidim").version %>"
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
Supports generating the app with the GitHub's version of `decidim` in a specific branch.

#### :pushpin: Related Issues
Closes #29.

#### :clipboard: Subtasks
- [x] Add flag to the generator
- [x] Use flag in the Gemfile template

#### :ghost: GIF
![](https://media.giphy.com/media/5HD9KbsVlFQnS/giphy.gif)

