### PR TITLE
Move helper to test module

### DIFF
--- a/decidim-dev/lib/decidim/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/test/base_spec_helper.rb
@@ -39,10 +39,8 @@ RSpec.configure do |config|
   # examples within a transaction, comment the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = false
+
+  config.include TranslationHelpers
 end
 
 require_relative "i18n_spec"
-
-def translated(field, locale: I18n.locale)
-  field.try(:[], locale.to_s)
-end

--- a/decidim-dev/lib/decidim/test/rspec_support/translation_helpers.rb
+++ b/decidim-dev/lib/decidim/test/rspec_support/translation_helpers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# A collection of methods to help dealing with translated attributes.
+module TranslationHelpers
+  # Gives the localized version of the attribute for the given locale. The
+  # locale defaults to the application's default one.
+  #
+  # It is intended to be used to avoid the implementation details, so that the
+  # translated attributes implementation can change more easily.
+  def translated(field, locale: I18n.locale)
+    field.try(:[], locale.to_s)
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Moves a test helper method to a module, which is included by RSpec.

#### :pushpin: Related Issues
Improves #145

#### :ghost: GIF
![](https://media.giphy.com/media/3oz8xU3se3UEQJirMQ/source.gif)

