### PR TITLE
Add `published_at` field to processes

### DIFF
--- a/Gemfile.common
+++ b/Gemfile.common
@@ -1,1 +1,2 @@
 gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git", tag: "df0bd8e"
+gem "rectify", git: "https://github.com/mrcasals/rectify.git", branch: "query_to_ary"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,16 @@
 GIT
+  remote: https://github.com/mrcasals/rectify.git
+  revision: cf6e4d280aabc5528985739ae76d8beb9984f88f
+  branch: query_to_ary
+  specs:
+    rectify (0.7.0)
+      activemodel (>= 4.1.0)
+      activerecord (>= 4.1.0)
+      activesupport (>= 4.1.0)
+      virtus (~> 1.0.5)
+      wisper (>= 1.6.1)
+
+GIT
   remote: https://github.com/sgruhier/foundation_rails_helper.git
   revision: df0bd8eca1b43b8bfdcb163f9e1e3b3b9ab0595e
   tag: df0bd8e
@@ -294,12 +306,6 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    rectify (0.6.1)
-      activemodel (>= 4.1.0)
-      activerecord (>= 4.1.0)
-      activesupport (>= 4.1.0)
-      virtus (~> 1.0.5)
-      wisper (>= 1.6.1)
     redis (3.3.1)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
@@ -409,6 +415,7 @@ DEPENDENCIES
   decidim-system!
   foundation_rails_helper!
   rake (~> 11.0)
+  rectify!
   rspec (~> 3.0)
   rspec_junit_formatter (= 0.2.3)
   rubocop (~> 0.44.1)

--- a/decidim-admin/app/commands/decidim/admin/publish_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/publish_participatory_process.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A command that sets a participatory process as published.
+    class PublishParticipatoryProcess < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # process - A ParticipatoryProcess that will be published
+      def initialize(process)
+        @process = process
+      end
+
+      # Executes the command. Braodcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the data wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if process.nil? || process.published?
+
+        publish_process
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :process
+
+      def publish_process
+        process.update_attribute(:published_at, Time.zone.now)
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/publish_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/publish_participatory_process.rb
@@ -28,7 +28,7 @@ module Decidim
       attr_reader :process
 
       def publish_process
-        process.update_attribute(:published_at, Time.zone.now)
+        process.update_attribute(:published_at, Time.current)
       end
     end
   end

--- a/decidim-admin/app/commands/decidim/admin/unpublish_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/unpublish_participatory_process.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A command that sets a participatory process as unpublished.
+    class UnpublishParticipatoryProcess < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # process - A ParticipatoryProcess that will be unpublished
+      def initialize(process)
+        @process = process
+      end
+
+      # Executes the command. Braodcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the data wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if process.nil? || !process.published?
+
+        unpublish_process
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :process
+
+      def unpublish_process
+        process.update_attribute(:published_at, nil)
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_publications_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_publications_controller.rb
@@ -44,10 +44,6 @@ module Decidim
         @participatory_process ||=
           current_organization.participatory_processes.find(params[:participatory_process_id])
       end
-
-      def policy_class(_record)
-        Decidim::Admin::ParticipatoryProcessPolicy
-      end
     end
   end
 end

--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_publications_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_publications_controller.rb
@@ -7,7 +7,7 @@ module Decidim
     #
     class ParticipatoryProcessPublicationsController < ApplicationController
       def create
-        authorize ParticipatoryProcess
+        authorize! :publish, participatory_process
 
         PublishParticipatoryProcess.call(participatory_process) do
           on(:ok) do
@@ -23,7 +23,7 @@ module Decidim
       end
 
       def destroy
-        authorize participatory_process
+        authorize! :publish, participatory_process
 
         UnpublishParticipatoryProcess.call(participatory_process) do
           on(:ok) do

--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_publications_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_publications_controller.rb
@@ -12,13 +12,13 @@ module Decidim
         PublishParticipatoryProcess.call(participatory_process) do
           on(:ok) do
             flash[:notice] = I18n.t("participatory_participatory_process_publications.create.success", scope: "decidim.admin")
-            redirect_to :back
           end
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("participatory_participatory_process_publications.create.error", scope: "decidim.admin")
-            redirect_to :back
           end
+
+          redirect_back(fallback_location: participatory_processes_path)
         end
       end
 
@@ -28,13 +28,13 @@ module Decidim
         UnpublishParticipatoryProcess.call(participatory_process) do
           on(:ok) do
             flash[:notice] = I18n.t("participatory_participatory_process_publications.destroy.success", scope: "decidim.admin")
-            redirect_to :back
           end
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("participatory_participatory_process_publications.destroy.error", scope: "decidim.admin")
-            redirect_to :back
           end
+
+          redirect_back(fallback_location: participatory_processes_path)
         end
       end
 

--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_publications_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_publications_controller.rb
@@ -11,11 +11,11 @@ module Decidim
 
         PublishParticipatoryProcess.call(participatory_process) do
           on(:ok) do
-            flash[:notice] = I18n.t("participatory_participatory_process_publications.create.success", scope: "decidim.admin")
+            flash[:notice] = I18n.t("participatory_process_publications.create.success", scope: "decidim.admin")
           end
 
           on(:invalid) do
-            flash.now[:alert] = I18n.t("participatory_participatory_process_publications.create.error", scope: "decidim.admin")
+            flash.now[:alert] = I18n.t("participatory_process_publications.create.error", scope: "decidim.admin")
           end
 
           redirect_back(fallback_location: participatory_processes_path)
@@ -27,11 +27,11 @@ module Decidim
 
         UnpublishParticipatoryProcess.call(participatory_process) do
           on(:ok) do
-            flash[:notice] = I18n.t("participatory_participatory_process_publications.destroy.success", scope: "decidim.admin")
+            flash[:notice] = I18n.t("participatory_process_publications.destroy.success", scope: "decidim.admin")
           end
 
           on(:invalid) do
-            flash.now[:alert] = I18n.t("participatory_participatory_process_publications.destroy.error", scope: "decidim.admin")
+            flash.now[:alert] = I18n.t("participatory_process_publications.destroy.error", scope: "decidim.admin")
           end
 
           redirect_back(fallback_location: participatory_processes_path)
@@ -41,7 +41,8 @@ module Decidim
       private
 
       def participatory_process
-        current_organization.participatory_processes.find(params[:participatory_process_id])
+        @participatory_process ||=
+          current_organization.participatory_processes.find(params[:participatory_process_id])
       end
 
       def policy_class(_record)

--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_publications_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_publications_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require_dependency "decidim/admin/application_controller"
+
+module Decidim
+  module Admin
+    # Controller that allows managing all the Admins.
+    #
+    class ParticipatoryProcessPublicationsController < ApplicationController
+      def create
+        authorize ParticipatoryProcess
+
+        PublishParticipatoryProcess.call(participatory_process) do
+          on(:ok) do
+            flash[:notice] = I18n.t("participatory_participatory_process_publications.create.success", scope: "decidim.admin")
+            redirect_to :back
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("participatory_participatory_process_publications.create.error", scope: "decidim.admin")
+            redirect_to :back
+          end
+        end
+      end
+
+      def destroy
+        authorize participatory_process
+
+        UnpublishParticipatoryProcess.call(participatory_process) do
+          on(:ok) do
+            flash[:notice] = I18n.t("participatory_participatory_process_publications.destroy.success", scope: "decidim.admin")
+            redirect_to :back
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("participatory_participatory_process_publications.destroy.error", scope: "decidim.admin")
+            redirect_to :back
+          end
+        end
+      end
+
+      private
+
+      def participatory_process
+        current_organization.participatory_processes.find(params[:participatory_process_id])
+      end
+
+      def policy_class(_record)
+        Decidim::Admin::ParticipatoryProcessPolicy
+      end
+    end
+  end
+end

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
@@ -11,6 +11,7 @@
     <tr>
       <th><%= t("models.participatory_process.fields.title", scope: "decidim.admin") %></th>
       <th><%= t("models.participatory_process.fields.promoted", scope: "decidim.admin") %></th>
+      <th><%= t("models.participatory_process.fields.published", scope: "decidim.admin") %></th>
       <th><%= t("models.participatory_process.fields.created_at", scope: "decidim.admin") %></th>
       <th class="actions"><%= t("actions.title", scope: "decidim.admin") %></th>
     </tr>
@@ -25,11 +26,22 @@
           <%= humanize_boolean process.promoted? %>
         </td>
         <td>
+          <%= humanize_boolean process.published? %>
+        </td>
+        <td>
           <%= l process.created_at, format: :short %>
         </td>
         <td class="actions">
           <% if can? :update, process %>
             <%= link_to t("actions.edit", scope: "decidim.admin"), ['edit', process] %>
+          <% end %>
+
+          <% if can? :publish, process %>
+            <% if process.published? %>
+              <%= link_to t("actions.unpublish", scope: "decidim.admin"), participatory_process_publish_path(process), method: :delete, class: "small button secondary" %>
+            <% else %>
+              <%= link_to t("actions.publish", scope: "decidim.admin"), participatory_process_publish_path(process), method: :post, class: "small button secondary" %>
+            <% end %>
           <% end %>
 
           <% if can? :destroy, process %>

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/show.html.erb
@@ -8,6 +8,15 @@
   <% if can? :update, @participatory_process %>
     <%= link_to t("decidim.admin.actions.edit"), ['edit', @participatory_process] %>
   <% end %>
+
+  <% if can? :publish, @participatory_process %>
+    <% if @participatory_process.published? %>
+      <%= link_to t("actions.unpublish", scope: "decidim.admin"), participatory_process_publish_path(@participatory_process), method: :delete, class: "small button secondary" %>
+    <% else %>
+      <%= link_to t("actions.publish", scope: "decidim.admin"), participatory_process_publish_path(@participatory_process), method: :post, class: "small button secondary" %>
+    <% end %>
+  <% end %>
+
   <% if can? :destroy, @participatory_process %>
     <%= link_to t("decidim.admin.actions.destroy"), @participatory_process, method: :delete, class: "alert button", data: { confirm: t("decidim.admin.actions.confirm_destroy") } %>
   <% end %>

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -43,7 +43,7 @@ ca:
             start_date: Data d'inici
             title: Títol
           name: Name
-      participatory_participatory_process_publications:
+      participatory_process_publications:
         create:
           error: S'ha produït un error en publicar aquest procés participatiu.
           success: El procés participatiu s'ha publicat correctament.

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -13,8 +13,10 @@ ca:
         destroy: Eliminar
         edit: Editar
         new: Nou %{name}
+        publish: Publicar
         title: Accions
         unauthorized: No tens permís per realitzar aquesta acció.
+        unpublish: Despublicar
       decidim:
         admin:
           participatory_process_steps:
@@ -29,6 +31,7 @@ ca:
           fields:
             created_at: Data de creació
             promoted: Destacat
+            published: Publicat
             title: Títol
           name: Procés participatiu
           validations:
@@ -40,6 +43,13 @@ ca:
             start_date: Data d'inici
             title: Títol
           name: Name
+      participatory_participatory_process_publications:
+        create:
+          error: S'ha produït un error en publicar aquest procés participatiu.
+          success: El procés participatiu s'ha publicat correctament.
+        destroy:
+          error: S'ha produït un error en despublicar aquest procés participatiu.
+          success: El procés participatiu s'ha despublicat correctament.
       participatory_process_step_activations:
         create:
           error: S'ha produït un error en activar aquesta fase de procés participatiu.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -13,8 +13,10 @@ en:
         destroy: Destroy
         edit: Edit
         new: New %{name}
+        publish: Publish
         title: Actions
         unauthorized: You are not authorized to perform this action
+        unpublish: Unpublish
       decidim:
         admin:
           participatory_process_steps:
@@ -29,6 +31,7 @@ en:
           fields:
             created_at: Created at
             promoted: Highlighted
+            published: Published
             title: Title
           name: Participatory process
           validations:
@@ -40,6 +43,13 @@ en:
             start_date: Start date
             title: Title
           name: Participatory process step
+      participatory_participatory_process_publications:
+        create:
+          error: There was an error publishing this participatory process.
+          success: Participatory process published successfully
+        destroy:
+          error: There was an error unpublishing this participatory process.
+          success: Participatory process unpublished successfully
       participatory_process_step_activations:
         create:
           error: There was an error activating this participatory process step.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
             start_date: Start date
             title: Title
           name: Participatory process step
-      participatory_participatory_process_publications:
+      participatory_process_publications:
         create:
           error: There was an error publishing this participatory process.
           success: Participatory process published successfully

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -13,8 +13,10 @@ es:
         destroy: Eliminar
         edit: Editar
         new: Nuevo %{name}
+        publish: Publicar
         title: Acciones
         unauthorized: No tienes permiso para realizar esta acción.
+        unpublish: Despublicar
       decidim:
         admin:
           participatory_process_steps:
@@ -29,6 +31,7 @@ es:
           fields:
             created_at: Fecha de creación
             promoted: Destacado
+            published: Publicado
             title: Título
           name: Proceso participativo
           validations:
@@ -40,6 +43,13 @@ es:
             start_date: Fecha de inicio
             title: Título
           name: Fase de proceso participativo
+      participatory_participatory_process_publications:
+        create:
+          error: Se ha producido un error al publicar este proceso participativo.
+          success: El proceso participativo se ha publicado correctamente.
+        destroy:
+          error: Se ha producido un error al despublicar este proceso participativo.
+          success: El proceso participativo se ha despublicado correctamente.
       participatory_process_step_activations:
         create:
           error: Se ha producido un error al activar esta fase de proceso participativo.

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -43,7 +43,7 @@ es:
             start_date: Fecha de inicio
             title: Título
           name: Fase de proceso participativo
-      participatory_participatory_process_publications:
+      participatory_process_publications:
         create:
           error: Se ha producido un error al publicar este proceso participativo.
           success: El proceso participativo se ha publicado correctamente.

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -2,6 +2,8 @@
 Decidim::Admin::Engine.routes.draw do
   constraints(->(request) { Decidim::Admin::OrganizationDashboardConstraint.new(request).matches? }) do
     resources :participatory_processes do
+      resource :publish, controller: "participatory_process_publications", only: [:create, :destroy]
+
       resources :steps, controller: "participatory_process_steps", except: :index do
         resource :activate, controller: "participatory_process_step_activations", only: [:create, :destroy]
         collection do

--- a/decidim-admin/spec/commands/publish_participatory_process_spec.rb
+++ b/decidim-admin/spec/commands/publish_participatory_process_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe Decidim::Admin::PublishParticipatoryProcess do
+  let(:my_process) { create :participatory_process, :unpublished }
+
+  subject { described_class.new(my_process) }
+
+  context "when the process is nil" do
+    let(:my_process) { nil }
+
+    it "is not valid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
+  context "when the process is published" do
+    let(:my_process) { create :participatory_process }
+
+    it "is not valid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
+  context "when the process is not published" do
+    it "is valid" do
+      expect { subject.call }.to broadcast(:ok)
+    end
+
+    it "publishes it" do
+      subject.call
+      my_process.reload
+      expect(my_process).to be_published
+    end
+  end
+end

--- a/decidim-admin/spec/commands/unpublish_participatory_process_spec.rb
+++ b/decidim-admin/spec/commands/unpublish_participatory_process_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe Decidim::Admin::UnpublishParticipatoryProcess do
+  let(:my_process) { create :participatory_process }
+
+  subject { described_class.new(my_process) }
+
+  context "when the process is nil" do
+    let(:my_process) { nil }
+
+    it "is not valid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
+  context "when the process is not published" do
+    let(:my_process) { create :participatory_process, :unpublished }
+
+    it "is not valid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
+  context "when the process is published" do
+    it "is valid" do
+      expect { subject.call }.to broadcast(:ok)
+    end
+
+    it "unpublishes it" do
+      subject.call
+      my_process.reload
+      expect(my_process).not_to be_published
+    end
+  end
+end

--- a/decidim-admin/spec/features/manage_participatory_processes_spec.rb
+++ b/decidim-admin/spec/features/manage_participatory_processes_spec.rb
@@ -147,6 +147,70 @@ describe "Manage participatory processes", type: :feature do
     end
   end
 
+  context "publishing a process" do
+    let!(:participatory_process) { create(:participatory_process, :unpublished, organization: organization) }
+
+    context "from the index page" do
+      it "publishes the process" do
+        click_link "Publish"
+        expect(page).to have_content("published successfully")
+        expect(page).to have_content("Unpublish")
+        expect(current_path).to eq decidim_admin.participatory_processes_path
+
+        participatory_process.reload
+        expect(participatory_process).to be_published
+      end
+    end
+
+    context "from the process page" do
+      before do
+        click_link translated(participatory_process.title)
+      end
+
+      it "publishes the process" do
+        click_link "Publish"
+        expect(page).to have_content("published successfully")
+        expect(page).to have_content("Unpublish")
+        expect(current_path).to eq decidim_admin.participatory_process_path(participatory_process)
+
+        participatory_process.reload
+        expect(participatory_process).to be_published
+      end
+    end
+  end
+
+  context "unpublishing a process" do
+    let!(:participatory_process) { create(:participatory_process, organization: organization) }
+
+    context "from the index page" do
+      it "unpublishes the process" do
+        click_link "Unpublish"
+        expect(page).to have_content("unpublished successfully")
+        expect(page).to have_content("Publish")
+        expect(current_path).to eq decidim_admin.participatory_processes_path
+
+        participatory_process.reload
+        expect(participatory_process).not_to be_published
+      end
+    end
+
+    context "from the process page" do
+      before do
+        click_link translated(participatory_process.title)
+      end
+
+      it "unpublishes the process" do
+        click_link "Unpublish"
+        expect(page).to have_content("unpublished successfully")
+        expect(page).to have_content("Publish")
+        expect(current_path).to eq decidim_admin.participatory_process_path(participatory_process)
+
+        participatory_process.reload
+        expect(participatory_process).not_to be_published
+      end
+    end
+  end
+
   context "when there are multiple organizations in the system" do
     let!(:external_participatory_process) { create(:participatory_process) }
 

--- a/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
@@ -14,23 +14,16 @@ module Decidim
     private
 
     def participatory_process
-      @participatory_process ||= if current_user && current_user.role?(:admin)
-                                   all_processes
-                                 else
-                                   participatory_processes
-                                 end.where(id: params[:id]).first
+      @participatory_process ||=
+        AvailableProcessesForUser.new(current_user, current_organization).query.where(id: params[:id]).first
     end
 
     def participatory_processes
-      @participatory_processes ||= all_processes.published
-    end
-
-    def all_processes
-      @all_processes ||= current_organization.participatory_processes.includes(:active_step)
+      @participatory_processes ||= PublishedProcesses.new(current_organization)
     end
 
     def promoted_processes
-      @promoted_processes ||= participatory_processes.where(promoted: true)
+      @promoted_processes ||= participatory_processes | PromotedProcesses.new
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
@@ -8,18 +8,25 @@ module Decidim
     helper_method :participatory_processes, :participatory_process, :promoted_processes
 
     def show
-      # render status: :not_found and return unless participatory_process
       raise ActionController::RoutingError, "Not Found" unless participatory_process
     end
 
     private
 
     def participatory_process
-      @participatory_process ||= participatory_processes.where(id: params[:id]).first
+      @participatory_process ||= if current_user && current_user.role?(:admin)
+                                   all_processes
+                                 else
+                                   participatory_processes
+                                 end.where(id: params[:id]).first
     end
 
     def participatory_processes
-      @participatory_processes ||= current_organization.participatory_processes.published.includes(:active_step)
+      @participatory_processes ||= all_processes.published
+    end
+
+    def all_processes
+      @all_processes ||= current_organization.participatory_processes.includes(:active_step)
     end
 
     def promoted_processes

--- a/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
@@ -7,14 +7,19 @@ module Decidim
   class ParticipatoryProcessesController < ApplicationController
     helper_method :participatory_processes, :participatory_process, :promoted_processes
 
+    def show
+      # render status: :not_found and return unless participatory_process
+      raise ActionController::RoutingError, "Not Found" unless participatory_process
+    end
+
     private
 
     def participatory_process
-      @participatory_process ||= participatory_processes.find(params[:id])
+      @participatory_process ||= participatory_processes.where(id: params[:id]).first
     end
 
     def participatory_processes
-      @participatory_processes ||= current_organization.participatory_processes.includes(:active_step)
+      @participatory_processes ||= current_organization.participatory_processes.published.includes(:active_step)
     end
 
     def promoted_processes

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -21,5 +21,9 @@ module Decidim
     def self.published
       where.not(published_at: nil)
     end
+
+    def published?
+      published_at.present?
+    end
   end
 end

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -18,10 +18,16 @@ module Decidim
     mount_uploader :hero_image, Decidim::HeroImageUploader
     mount_uploader :banner_image, Decidim::BannerImageUploader
 
+    # Scope to return only the published processes.
+    #
+    # Returns an ActiveRecord::Relation.
     def self.published
       where.not(published_at: nil)
     end
 
+    # Checks whether the process has been published or not.
+    #
+    # Returns a boolean.
     def published?
       published_at.present?
     end

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -17,5 +17,9 @@ module Decidim
 
     mount_uploader :hero_image, Decidim::HeroImageUploader
     mount_uploader :banner_image, Decidim::BannerImageUploader
+
+    def self.published
+      where.not(published_at: nil)
+    end
   end
 end

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -29,7 +29,7 @@ module Decidim
       @ability ||= Ability.new(self)
     end
 
-    # Check if the user has the given `role` or not.
+    # Checks if the user has the given `role` or not.
     #
     # role - a String or a Symbol that represents the role that is being
     #   checked

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -24,6 +24,11 @@ module Decidim
 
     delegate :can?, to: :ability
 
+    # Gets the ability instance for the given user.
+    def ability
+      @ability ||= Ability.new(self)
+    end
+
     # Check if the user has the given `role` or not.
     #
     # role - a String or a Symbol that represents the role that is being
@@ -32,11 +37,6 @@ module Decidim
     # Returns a boolean.
     def role?(role)
       roles.include?(role.to_s)
-    end
-
-    # Gets the ability instance for the given user.
-    def ability
-      @ability ||= Ability.new(self)
     end
 
     private

--- a/decidim-core/app/queries/decidim/available_processes_for_user.rb
+++ b/decidim-core/app/queries/decidim/available_processes_for_user.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 module Decidim
+  # A query object to retrieve available processes for the user organization.
+  # Changes the scope based on the user role.
   class AvailableProcessesForUser < Rectify::Query
     def initialize(user, organization)
       @user = user

--- a/decidim-core/app/queries/decidim/available_processes_for_user.rb
+++ b/decidim-core/app/queries/decidim/available_processes_for_user.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Decidim
+  class AvailableProcessesForUser < Rectify::Query
+    def initialize(user, organization)
+      @user = user
+      @organization = organization
+    end
+
+    def query
+      if user && user.role?(:admin)
+        OrganizationProcesses.new(organization).query
+      else
+        PublishedProcesses.new(organization).query
+      end
+    end
+
+    private
+
+    attr_reader :user, :organization
+  end
+end

--- a/decidim-core/app/queries/decidim/available_processes_for_user.rb
+++ b/decidim-core/app/queries/decidim/available_processes_for_user.rb
@@ -3,13 +3,24 @@ module Decidim
   # A query object to retrieve available processes for the user organization.
   # Changes the scope based on the user role.
   class AvailableProcessesForUser < Rectify::Query
+    # Initializes the query.
+    #
+    # user - the User that needs the processes checked.
+    # organization - the current Organization.
     def initialize(user, organization)
       @user = user
       @organization = organization
     end
 
+    # Returns the processes for the given user and organization. When no
+    # organization is given, it returns an empty ActiveRecord::Relation.
+    # Otherwise checks the user role and organization and returns all the
+    # organization processes if the user is an admin, or its published
+    # processes otherwise.
     def query
-      if user && user.role?(:admin)
+      return ParticipatoryProcess.none unless organization
+
+      if user && user.role?(:admin) && user.organization == organization
         OrganizationProcesses.new(organization).query
       else
         PublishedProcesses.new(organization).query

--- a/decidim-core/app/queries/decidim/organization_processes.rb
+++ b/decidim-core/app/queries/decidim/organization_processes.rb
@@ -2,11 +2,18 @@
 module Decidim
   # A query object to retrieve all processes from a single organization.
   class OrganizationProcesses < Rectify::Query
+    # Initializes the query.
+    #
+    # organization - The organization that needs its processes fetched.
     def initialize(organization)
       @organization = organization
     end
 
+    # Gets the particiaptory processes form the given organization, prefetching
+    # their active step. If no organization is given, it returns an empty
+    # ActiveRecord::Relation.
     def query
+      return ParticipatoryProcess.none unless organization
       organization.participatory_processes.includes(:active_step)
     end
 

--- a/decidim-core/app/queries/decidim/organization_processes.rb
+++ b/decidim-core/app/queries/decidim/organization_processes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 module Decidim
+  # A query object to retrieve all processes from a single organization.
   class OrganizationProcesses < Rectify::Query
     def initialize(organization)
       @organization = organization

--- a/decidim-core/app/queries/decidim/organization_processes.rb
+++ b/decidim-core/app/queries/decidim/organization_processes.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Decidim
+  class OrganizationProcesses < Rectify::Query
+    def initialize(organization)
+      @organization = organization
+    end
+
+    def query
+      organization.participatory_processes.includes(:active_step)
+    end
+
+    private
+
+    attr_reader :organization
+  end
+end

--- a/decidim-core/app/queries/decidim/promoted_processes.rb
+++ b/decidim-core/app/queries/decidim/promoted_processes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Decidim
+  class PromotedProcesses < Rectify::Query
+    def query
+      ParticipatoryProcess.where(promoted: true)
+    end
+  end
+end

--- a/decidim-core/app/queries/decidim/promoted_processes.rb
+++ b/decidim-core/app/queries/decidim/promoted_processes.rb
@@ -2,6 +2,9 @@
 module Decidim
   # A query object to retrieve promoted processes.
   class PromotedProcesses < Rectify::Query
+    # Returns all promoted processes. This is intended to be merged with
+    # another query that sets the basic scope, for example
+    # `OrganizationProcesses`.
     def query
       ParticipatoryProcess.where(promoted: true)
     end

--- a/decidim-core/app/queries/decidim/promoted_processes.rb
+++ b/decidim-core/app/queries/decidim/promoted_processes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 module Decidim
+  # A query object to retrieve promoted processes.
   class PromotedProcesses < Rectify::Query
     def query
       ParticipatoryProcess.where(promoted: true)

--- a/decidim-core/app/queries/decidim/published_processes.rb
+++ b/decidim-core/app/queries/decidim/published_processes.rb
@@ -2,10 +2,16 @@
 module Decidim
   # A query object to retrieve promoted processes.
   class PublishedProcesses < Rectify::Query
+    # Initializes the query.
+    #
+    # organization - the Organization that needs its processes fetched.
+    #   Optional.
     def initialize(organization = nil)
       @organization = organization
     end
 
+    # Returns all processes from the organization, if set. Otherwise returns
+    # all processes from the database.
     def query
       scope.includes(:active_step).published
     end

--- a/decidim-core/app/queries/decidim/published_processes.rb
+++ b/decidim-core/app/queries/decidim/published_processes.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Decidim
+  class PublishedProcesses < Rectify::Query
+    def initialize(organization = nil)
+      @organization = organization
+    end
+
+    def query
+      scope.includes(:active_step).published
+    end
+
+    private
+
+    attr_reader :organization
+
+    def scope
+      return ParticipatoryProcess.all unless organization
+
+      OrganizationProcesses.new(organization).query
+    end
+  end
+end

--- a/decidim-core/app/queries/decidim/published_processes.rb
+++ b/decidim-core/app/queries/decidim/published_processes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 module Decidim
+  # A query object to retrieve promoted processes.
   class PublishedProcesses < Rectify::Query
     def initialize(organization = nil)
       @organization = organization

--- a/decidim-core/db/migrate/20161025125300_add_published_at_to_processes.rb
+++ b/decidim-core/db/migrate/20161025125300_add_published_at_to_processes.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToProcesses < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_participatory_processes, :published_at, :datetime, index: true
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -55,6 +55,7 @@ if !Rails.env.production? || ENV["SEED"]
     hero_image: File.new(File.join(File.dirname(__FILE__), "seeds", "city.jpeg")),
     banner_image: File.new(File.join(File.dirname(__FILE__), "seeds", "city2.jpeg")),
     promoted: true,
+    published_at: 2.weeks.ago,
     organization: staging_organization
   )
 
@@ -83,6 +84,35 @@ if !Rails.env.production? || ENV["SEED"]
     },
     hero_image: File.new(File.join(File.dirname(__FILE__), "seeds", "city2.jpeg")),
     banner_image: File.new(File.join(File.dirname(__FILE__), "seeds", "city3.jpeg")),
+    published_at: 1.week.ago,
+    organization: staging_organization
+  )
+
+  Decidim::ParticipatoryProcess.create!(
+    title: {
+      en: "Plant new trees at the Seaside Boulevard",
+      es: "Plantar nuevos árboles en el Paseo marítimo",
+      ca: "Plantar nous arbres al Passeig marítim"
+    },
+    slug: "plant-new-trees-at-the-seaside-boulevard",
+    subtitle: {
+      en: "A greener space close to the beach",
+      es: "Un espacio más verde cerca de la playa",
+      ca: "Un espai més verd a prop de la platja"
+    },
+    hashtag: "#seasideTrees",
+    short_description: {
+      en: "<p>Short description</p>",
+      es: "<p>Descripción corta</p>",
+      ca: "<p>Descripció curta</p>"
+    },
+    description: {
+      en: "<p>Description</p>",
+      es: "<p>Descripción</p>",
+      ca: "<p>Descripció</p>"
+    },
+    hero_image: File.new(File.join(File.dirname(__FILE__), "seeds", "city3.jpeg")),
+    banner_image: File.new(File.join(File.dirname(__FILE__), "seeds", "city2.jpeg")),
     organization: staging_organization
   )
 

--- a/decidim-core/spec/controllers/participatory_processes_controller_spec.rb
+++ b/decidim-core/spec/controllers/participatory_processes_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe ParticipatoryProcessesController, type: :controller do
+    routes { Decidim::Core::Engine.routes }
+    let(:organization) { create(:organization) }
+    let!(:unpublished_process) do
+      create(
+        :participatory_process,
+        :unpublished,
+        organization: organization
+      )
+    end
+
+    before do
+      @request.env["decidim.current_organization"] = organization
+    end
+
+    describe "GET show" do
+      context "when the process is unpublished" do
+        it "raises an error" do
+          expect do
+            get :show, params: { id: unpublished_process.id }
+          end.to raise_error(ActionController::RoutingError, "Not Found")
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -13,7 +13,7 @@ FactoryGirl.define do
     description       en: "<p>Description</p>", ca: "<p>Descripció</p>", es: "<p>Descripción</p>"
     hero_image { Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "decidim-dev", "spec", "support", "city.jpeg")) }
     banner_image { Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "decidim-dev", "spec", "support", "city2.jpeg")) }
-    published_at Time.current
+    published_at { Time.current }
     organization
 
     trait :promoted do

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -13,7 +13,7 @@ FactoryGirl.define do
     description       en: "<p>Description</p>", ca: "<p>Descripció</p>", es: "<p>Descripción</p>"
     hero_image { Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "decidim-dev", "spec", "support", "city.jpeg")) }
     banner_image { Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "decidim-dev", "spec", "support", "city2.jpeg")) }
-    published_at Time.zone.now
+    published_at Time.current
     organization
 
     trait :promoted do

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -13,10 +13,15 @@ FactoryGirl.define do
     description       en: "<p>Description</p>", ca: "<p>Descripció</p>", es: "<p>Descripción</p>"
     hero_image { Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "decidim-dev", "spec", "support", "city.jpeg")) }
     banner_image { Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "decidim-dev", "spec", "support", "city2.jpeg")) }
+    published_at Time.zone.now
     organization
 
     trait :promoted do
       promoted true
+    end
+
+    trait :unpublished do
+      published_at nil
     end
   end
 

--- a/decidim-core/spec/features/participatory_processes_spec.rb
+++ b/decidim-core/spec/features/participatory_processes_spec.rb
@@ -18,6 +18,7 @@ describe "Participatory Processes", type: :feature do
 
   context "when there are some processes" do
     let!(:promoted_process) { create(:participatory_process, :promoted, organization: organization) }
+    let!(:unpublished_process) { create(:participatory_process, :unpublished, organization: organization) }
 
     before do
       visit decidim.participatory_processes_path
@@ -37,6 +38,8 @@ describe "Participatory Processes", type: :feature do
         expect(page).to have_content(translated(participatory_process.title, locale: :en))
         expect(page).to have_content(translated(promoted_process.title, locale: :en))
         expect(page).to have_selector("article.card", count: 2)
+
+        expect(page).to_not have_content(translated(unpublished_process.title, locale: :en))
       end
     end
 

--- a/decidim-core/spec/queries/available_processes_for_user_spec.rb
+++ b/decidim-core/spec/queries/available_processes_for_user_spec.rb
@@ -10,8 +10,26 @@ describe Decidim::AvailableProcessesForUser do
   subject { described_class.new(user, organization) }
 
   describe "#query" do
-    context "when the user is an admin" do
+    context "when no organization is given" do
       let(:user) { create :user, :admin }
+      subject { described_class.new(user, nil) }
+
+      it "returns an empty relation" do
+        expect(subject.query).to eq []
+        expect(subject.query).to be_kind_of(ActiveRecord::Relation)
+      end
+    end
+
+    context "when the user does not belong to the organization" do
+      let(:user) { create :user, :admin }
+
+      it "only returns the published processes from the given organization" do
+        expect(subject.query).to eq [published_process]
+      end
+    end
+
+    context "when the user is an admin" do
+      let(:user) { create :user, :admin, organization: organization }
 
       it "returns all processes from the given organization" do
         expect(subject.query).to match_array [published_process, unpublished_process]
@@ -27,7 +45,7 @@ describe Decidim::AvailableProcessesForUser do
     end
 
     context "when user is not an admin" do
-      let(:user) { create :user }
+      let(:user) { create :user, organization: organization }
 
       it "only returns the published processes from the given organization" do
         expect(subject.query).to eq [published_process]

--- a/decidim-core/spec/queries/available_processes_for_user_spec.rb
+++ b/decidim-core/spec/queries/available_processes_for_user_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Decidim::AvailableProcessesForUser do
+  let!(:organization) { create :organization }
+  let!(:external_process) { create :participatory_process }
+  let!(:published_process) { create :participatory_process, organization: organization }
+  let!(:unpublished_process) { create :participatory_process, :unpublished, organization: organization }
+
+  subject { described_class.new(user, organization) }
+
+  describe "#query" do
+    context "when the user is an admin" do
+      let(:user) { create :user, :admin }
+
+      it "returns all processes from the given organization" do
+        expect(subject.query).to match_array [published_process, unpublished_process]
+      end
+    end
+
+    context "when user is not set" do
+      let(:user) { }
+
+      it "only returns the published processes from the given organization" do
+        expect(subject.query).to eq [published_process]
+      end
+    end
+
+    context "when user is not an admin" do
+      let(:user) { create :user }
+
+      it "only returns the published processes from the given organization" do
+        expect(subject.query).to eq [published_process]
+      end
+    end
+  end
+end

--- a/decidim-core/spec/queries/organization_processes_spec.rb
+++ b/decidim-core/spec/queries/organization_processes_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Decidim::OrganizationProcesses do
+  let!(:external_process) { create :participatory_process }
+  let!(:organization_process) { create :participatory_process }
+
+  subject { described_class.new(organization_process.organization) }
+
+  describe "#query" do
+    it "only returns the processes form the given organization" do
+      expect(subject.query).to eq [organization_process]
+    end
+  end
+end

--- a/decidim-core/spec/queries/organization_processes_spec.rb
+++ b/decidim-core/spec/queries/organization_processes_spec.rb
@@ -4,10 +4,20 @@ require "spec_helper"
 describe Decidim::OrganizationProcesses do
   let!(:external_process) { create :participatory_process }
   let!(:organization_process) { create :participatory_process }
+  let(:organization) { organization_process.organization }
 
-  subject { described_class.new(organization_process.organization) }
+  subject { described_class.new(organization) }
 
   describe "#query" do
+    context "when no organization is given" do
+      let(:organization) { }
+
+      it "returns an empty relation" do
+        expect(subject.query).to eq []
+        expect(subject.query).to be_kind_of(ActiveRecord::Relation)
+      end
+    end
+
     it "only returns the processes form the given organization" do
       expect(subject.query).to eq [organization_process]
     end

--- a/decidim-core/spec/queries/promoted_processes_spec.rb
+++ b/decidim-core/spec/queries/promoted_processes_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Decidim::PromotedProcesses do
+  let!(:organization) { create :organization }
+  let!(:promoted_process) { create :participatory_process, :promoted, organization: organization }
+  let!(:unpromoted_process) { create :participatory_process, organization: organization }
+
+  subject { described_class.new }
+
+  describe "#query" do
+    it "only returns promoted processes" do
+      expect(subject.query).to eq [promoted_process]
+    end
+  end
+end

--- a/decidim-core/spec/queries/published_processes_spec.rb
+++ b/decidim-core/spec/queries/published_processes_spec.rb
@@ -13,7 +13,7 @@ describe Decidim::PublishedProcesses do
     context "when organization is set" do
       let(:current_organization) { organization }
 
-      it "only returns the processes from the given organization" do
+      it "only returns the published processes from the given organization" do
         expect(subject.query).to eq [published_process]
       end
     end
@@ -21,7 +21,7 @@ describe Decidim::PublishedProcesses do
     context "when organization is not set" do
       let(:current_organization) { nil }
 
-      it "only returns the processes from the given organization" do
+      it "returns all the published processes" do
         expect(subject.query).to match_array [published_process, external_process]
       end
     end

--- a/decidim-core/spec/queries/published_processes_spec.rb
+++ b/decidim-core/spec/queries/published_processes_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Decidim::PublishedProcesses do
+  let!(:organization) { create :organization }
+  let!(:external_process) { create :participatory_process }
+  let!(:published_process) { create :participatory_process, organization: organization }
+  let!(:unpublished_process) { create :participatory_process, :unpublished, organization: organization }
+
+  subject { described_class.new(current_organization) }
+
+  describe "#query" do
+    context "when organization is set" do
+      let(:current_organization) { organization }
+
+      it "only returns the processes from the given organization" do
+        expect(subject.query).to eq [published_process]
+      end
+    end
+
+    context "when organization is not set" do
+      let(:current_organization) { nil }
+
+      it "only returns the processes from the given organization" do
+        expect(subject.query).to match_array [published_process, external_process]
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/test/base_spec_helper.rb
@@ -23,6 +23,7 @@ require "factory_girl_rails"
 require "database_cleaner"
 require "byebug"
 require "cancan/matchers"
+require "rectify/rspec"
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
@@ -42,6 +43,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.include TranslationHelpers
+  config.include Rectify::RSpec::Helpers
 end
 
 require_relative "i18n_spec"

--- a/lib/generators/decidim/templates/Gemfile.erb
+++ b/lib/generators/decidim/templates/Gemfile.erb
@@ -14,6 +14,7 @@ gem 'puma', '~> 3.0'
 gem 'uglifier', '>= 1.3.0'
 
 gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git", tag: "df0bd8e"
+gem "rectify", git: "https://github.com/mrcasals/rectify.git", branch: "query_to_ary"
 
 group :development, :test do
   gem 'byebug', platform: :mri


### PR DESCRIPTION
#### :tophat: What? Why?

Publishes processes. Adds a way to publish processes from the admin part. Also, lets admins preview unpublished processes. We still need a way to warn the user that they are previewing an unpublished process from the UI/UX.
#### :pushpin: Related Issues

Fixes #121
#### :clipboard: Subtasks
- [x] Add `published_at` field to processes
- [x] Hide unpublished processes from public view
- [x] Add a way to publish processes from admin
- [x] Unpublished processes should be previewable for admins in public layouts
- [x] Add missing i18n
- [x] Add feature specs for both actions (publishing/unpublishing)
- [x] Rebase for #152 
- [x] Uses a Rectify fork until https://github.com/andypike/rectify/pull/36 is merged
- [ ] UI/UX: warn the user that they are previewing an unpublished process
- [x] Add [specs for queries](https://github.com/andypike/rectify/tree/v0.6.1#stubbing-query-objects-in-tests)

#### :ghost: GIF

![](http://i.imgur.com/5tf18EM.gif)
