### PR TITLE
Chore/update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,9 @@ gemspec path: "decidim-system"
 gemspec path: "decidim-admin"
 gemspec path: "decidim-dev"
 
-gem "rubocop"
+gem "rubocop", "~> 0.44.1"
 gem "rspec_junit_formatter", "0.2.3"
 gem "simplecov", "~> 0.12"
-gem "codecov", "~> 0.1.5"
+gem "codecov", "~> 0.1.6"
 
 eval(File.read(File.join(File.dirname(__FILE__), "Gemfile.common")))

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -1,1 +1,1 @@
-gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git"
+gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git", tag: "df0bd8e"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/sgruhier/foundation_rails_helper.git
   revision: df0bd8eca1b43b8bfdcb163f9e1e3b3b9ab0595e
+  tag: df0bd8e
   specs:
     foundation_rails_helper (2.0.0)
       actionpack (>= 4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       devise (~> 4.2)
       devise-i18n (~> 1.1.0)
       devise_invitable (~> 1.7.0)
-      foundation-rails (~> 6.2.3.0)
+      foundation-rails (~> 6.2.4.0)
       foundation_rails_helper (~> 2.0.0)
       jbuilder (~> 2.5)
       jquery-rails (~> 4.0)
@@ -47,7 +47,7 @@ PATH
       date_validator (~> 0.9.0)
       devise (~> 4.2)
       devise-i18n (~> 1.1.0)
-      foundation-rails (~> 6.2.3.0)
+      foundation-rails (~> 6.2.4.0)
       foundation_rails_helper (~> 2.0.0)
       high_voltage (~> 3.0.0)
       jbuilder (~> 2.5)
@@ -85,7 +85,7 @@ PATH
       devise (~> 4.2)
       devise-i18n (~> 1.1.0)
       devise_invitable (~> 1.7.0)
-      foundation-rails (~> 6.2.3.0)
+      foundation-rails (~> 6.2.4.0)
       foundation_rails_helper (~> 2.0.0)
       jbuilder (~> 2.5)
       jquery-rails (~> 4.0)
@@ -164,7 +164,7 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
-    codecov (0.1.5)
+    codecov (0.1.6)
       json
       simplecov
       url
@@ -204,7 +204,7 @@ GEM
       factory_girl (~> 4.7.0)
       railties (>= 3.0.0)
     ffi (1.9.14)
-    foundation-rails (6.2.3.0)
+    foundation-rails (6.2.4.0)
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
       sprockets-es6 (>= 0.9.0)
@@ -293,7 +293,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
     rake (11.3.0)
-    rb-fsevent (0.9.7)
+    rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     rectify (0.6.1)
@@ -335,7 +335,7 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.43.0)
+    rubocop (0.44.1)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -403,7 +403,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.12)
-  codecov (~> 0.1.5)
+  codecov (~> 0.1.6)
   decidim!
   decidim-admin!
   decidim-core!
@@ -414,7 +414,7 @@ DEPENDENCIES
   rake (~> 11.0)
   rspec (~> 3.0)
   rspec_junit_formatter (= 0.2.3)
-  rubocop
+  rubocop (~> 0.44.1)
   simplecov (~> 0.12)
 
 RUBY VERSION

--- a/decidim-admin/decidim-admin.gemspec
+++ b/decidim-admin/decidim-admin.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise-i18n", "~> 1.1.0"
   s.add_dependency "rectify", "~> 0.6"
   s.add_dependency "devise_invitable", "~> 1.7.0"
-  s.add_dependency "foundation-rails", "~> 6.2.3.0"
+  s.add_dependency "foundation-rails", "~> 6.2.4.0"
   s.add_dependency "sass-rails", "~> 5.0.0"
   s.add_dependency "jquery-rails", "~> 4.0"
   s.add_dependency "turbolinks", Decidim.rails_version

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise", "~> 4.2"
   s.add_dependency "devise-i18n", "~> 1.1.0"
   s.add_dependency "rectify", "~> 0.6"
-  s.add_dependency "foundation-rails", "~> 6.2.3.0"
+  s.add_dependency "foundation-rails", "~> 6.2.4.0"
   s.add_dependency "sass-rails", "~> 5.0.0"
   s.add_dependency "jquery-rails", "~> 4.0"
   s.add_dependency "turbolinks", Decidim.rails_version

--- a/decidim-system/decidim-system.gemspec
+++ b/decidim-system/decidim-system.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise-i18n", "~> 1.1.0"
   s.add_dependency "rectify", "~> 0.6"
   s.add_dependency "devise_invitable", "~> 1.7.0"
-  s.add_dependency "foundation-rails", "~> 6.2.3.0"
+  s.add_dependency "foundation-rails", "~> 6.2.4.0"
   s.add_dependency "sass-rails", "~> 5.0.0"
   s.add_dependency "jquery-rails", "~> 4.0"
   s.add_dependency "turbolinks", Decidim.rails_version

--- a/lib/generators/decidim/templates/Gemfile.erb
+++ b/lib/generators/decidim/templates/Gemfile.erb
@@ -13,7 +13,7 @@ gem "decidim", "<%= Gem::Specification.find_by_name("decidim").version %>"
 gem 'puma', '~> 3.0'
 gem 'uglifier', '>= 1.3.0'
 
-gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git"
+gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git", tag: "df0bd8e"
 
 group :development, :test do
   gem 'byebug', platform: :mri


### PR DESCRIPTION
#### :tophat: What? Why?
We should keep our dependencies up-to-date in order to address possible security concerns as well as be on the bleeding edge :hurtrealbad: .

#### :clipboard: Subtasks
- [x] Update dependencies
- [x] Use a fixed tag for foundation_rails_helpers

#### :ghost: GIF
![](https://media.giphy.com/media/syCa5ird7wp0c/giphy.gif)
